### PR TITLE
Fix potential server crash for offline player permissions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 Alpha 0.1.8.44
 - Add support for PlotSquared 7. Thanks, Bloody_Mind, for the suggestion!
 - Added the "/BigDoors PrepareDatabaseForV2" command. This will export your database to the format used by v2. Note that both the export and v2 are still experimental!
-- Fix rare issue with retrieving permissions for offline players that could result in a server crash. Thanks, VikEnd, for the bug report!
+- BREAKING API CHANGE: Fix rare issue with retrieving permissions for offline players that could result in a server crash. Thanks, VikEnd, for the bug report!
 
 Alpha 0.1.8.43
 - Fix startup issue on older versions of MC. Thanks, Trombettino, for the report!

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 Alpha 0.1.8.44
 - Add support for PlotSquared 7. Thanks, Bloody_Mind, for the suggestion!
 - Added the "/BigDoors PrepareDatabaseForV2" command. This will export your database to the format used by v2. Note that both the export and v2 are still experimental!
+- Fix rare issue with retrieving permissions for offline players that could result in a server crash. Thanks, VikEnd, for the bug report!
 
 Alpha 0.1.8.43
 - Fix startup issue on older versions of MC. Thanks, Trombettino, for the report!

--- a/core/src/main/java/nl/pim16aap2/bigDoors/AutoCloseScheduler.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/AutoCloseScheduler.java
@@ -1,10 +1,10 @@
 package nl.pim16aap2.bigDoors;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class AutoCloseScheduler
 {
@@ -70,7 +70,7 @@ public class AutoCloseScheduler
                     }
                     else
                         plugin.getDoorOpener(door.getType())
-                            .openDoor(plugin.getCommander().getDoor(null, door.getDoorUID()), time, instantOpen, false);
+                            .openDoorFuture(plugin.getCommander().getDoor(null, door.getDoorUID()), time, instantOpen, false);
                 }
                 deleteTimer(door.getDoorUID());
             }

--- a/core/src/main/java/nl/pim16aap2/bigDoors/BigDoors.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/BigDoors.java
@@ -77,6 +77,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 // TODO: Drawbridges that were created when flat, should remember that direction for opening.
@@ -434,13 +435,13 @@ public class BigDoors extends JavaPlugin implements Listener
         return PACKAGE_VERSION;
     }
 
-    public String canBreakBlock(UUID playerUUID, String playerName, Location loc)
+    public CompletableFuture<@Nullable String> canBreakBlock(UUID playerUUID, String playerName, Location loc)
     {
         return protCompatMan.canBreakBlock(playerUUID, playerName, loc);
     }
 
-    public String canBreakBlocksBetweenLocs(UUID playerUUID, String playerName, World world, Location loc1,
-                                            Location loc2)
+    public CompletableFuture<@Nullable String> canBreakBlocksBetweenLocs(
+        UUID playerUUID, String playerName, World world, Location loc1, Location loc2)
     {
         return protCompatMan.canBreakBlocksBetweenLocs(playerUUID, playerName, world, loc1, loc2);
     }

--- a/core/src/main/java/nl/pim16aap2/bigDoors/BigDoors.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/BigDoors.java
@@ -439,13 +439,15 @@ public class BigDoors extends JavaPlugin implements Listener
 
     public CompletableFuture<@Nullable String> canBreakBlock(UUID playerUUID, String playerName, Location loc)
     {
-        return protCompatMan.canBreakBlock(playerUUID, playerName, loc);
+        return protCompatMan.canBreakBlock(playerUUID, playerName, loc)
+            .exceptionally(throwable -> Util.exceptionally(throwable, "ERROR"));
     }
 
     public CompletableFuture<@Nullable String> canBreakBlocksBetweenLocs(
         UUID playerUUID, String playerName, World world, Location loc1, Location loc2)
     {
-        return protCompatMan.canBreakBlocksBetweenLocs(playerUUID, playerName, world, loc1, loc2);
+        return protCompatMan.canBreakBlocksBetweenLocs(playerUUID, playerName, world, loc1, loc2)
+            .exceptionally(throwable -> Util.exceptionally(throwable, "ERROR"));
     }
 
     public ProtectionCompatManager getProtectionCompatManager()

--- a/core/src/main/java/nl/pim16aap2/bigDoors/BigDoors.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/BigDoors.java
@@ -914,7 +914,7 @@ public class BigDoors extends JavaPlugin implements Listener
         final Opener opener = getDoorOpener(door.getType());
         return opener == null ?
                CompletableFuture.completedFuture(DoorOpenResult.TYPEDISABLED) :
-               opener.openDoor(door, time, instantOpen);
+               opener.openDoorFuture(door, time, instantOpen);
     }
 
     private CompletableFuture<Boolean> toggleDoorFuture0(Door door, double time, boolean instantOpen)
@@ -975,11 +975,6 @@ public class BigDoors extends JavaPlugin implements Listener
         return toggleDoorFuture0(getCommander().getDoor(null, doorUID), 0.0, false);
     }
 
-    private DoorOpenResult processFutureResult(CompletableFuture<DoorOpenResult> result)
-    {
-        return result.getNow(DoorOpenResult.ERROR);
-    }
-
     /**
      * @deprecated Use {@link #toggleDoorFuture(Door, double, boolean)} instead.
      * </p>
@@ -990,7 +985,7 @@ public class BigDoors extends JavaPlugin implements Listener
     {
         Opener opener = getDoorOpener(door.getType());
         return opener == null ? DoorOpenResult.TYPEDISABLED :
-               processFutureResult(opener.openDoor(door, time, instantOpen));
+               Opener.processFutureResult(opener.openDoorFuture(door, time, instantOpen));
     }
 
     /**

--- a/core/src/main/java/nl/pim16aap2/bigDoors/MyLogger.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/MyLogger.java
@@ -147,4 +147,14 @@ public class MyLogger
     {
         Bukkit.getLogger().log(level, "[" + pluginName + "] " + message);
     }
+
+    public void log(Throwable throwable)
+    {
+        severe(Util.throwableToString(throwable));
+    }
+
+    public void log(String message, Throwable throwable)
+    {
+        severe(message + "\n" + Util.throwableToString(throwable));
+    }
 }

--- a/core/src/main/java/nl/pim16aap2/bigDoors/VaultManager.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/VaultManager.java
@@ -113,7 +113,9 @@ public final class VaultManager implements IPermissionsManager
     {
         if (!vaultEnabled)
             return CompletableFuture.completedFuture(false);
-        return CompletableFuture.supplyAsync(() -> perms.playerHas(worldName, player, permission));
+        return CompletableFuture
+            .supplyAsync(() -> perms.playerHas(worldName, player, permission))
+            .exceptionally(throwable -> Util.exceptionally(throwable, false));
     }
 
     private double evaluateFormula(String formula, int blockCount)

--- a/core/src/main/java/nl/pim16aap2/bigDoors/VaultManager.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/VaultManager.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.RegisteredServiceProvider;
 
 import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
 
 public final class VaultManager implements IPermissionsManager
 {
@@ -108,9 +109,11 @@ public final class VaultManager implements IPermissionsManager
         return vaultEnabled && perms.playerHas(player.getWorld().getName(), player, permission);
     }
 
-    public boolean hasPermission(OfflinePlayer player, String permission, String worldName)
+    public CompletableFuture<Boolean> hasPermission(OfflinePlayer player, String permission, String worldName)
     {
-        return vaultEnabled && perms.playerHas(worldName, player, permission);
+        if (!vaultEnabled)
+            return CompletableFuture.completedFuture(false);
+        return CompletableFuture.supplyAsync(() -> perms.playerHas(worldName, player, permission));
     }
 
     private double evaluateFormula(String formula, int blockCount)
@@ -133,7 +136,7 @@ public final class VaultManager implements IPermissionsManager
             return 0;
 
         // Try cache first
-        long priceID = blockCount * 100 + DoorType.getValue(type);
+        long priceID = blockCount * 100L + DoorType.getValue(type);
         if (menu.containsKey(priceID))
             return menu.get(priceID);
 

--- a/core/src/main/java/nl/pim16aap2/bigDoors/compatibility/ProtectionCompatManager.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/compatibility/ProtectionCompatManager.java
@@ -173,7 +173,8 @@ public class ProtectionCompatManager implements Listener
                 }
                 catch (InterruptedException e)
                 {
-                    e.printStackTrace();
+                    plugin.getMyLogger().log(
+                        "Interrupted while checking permissions for offline player: " + fakePlayer, e);
                     Thread.currentThread().interrupt();
                 }
                 catch (TimeoutException e)
@@ -185,7 +186,7 @@ public class ProtectionCompatManager implements Listener
                     plugin.getMyLogger().log("Failed to check permissions for offline player: " + fakePlayer, e);
                 }
                 return "ERROR";
-            });
+            }).exceptionally(throwable -> Util.exceptionally(throwable, "ERROR!"));
     }
 
     public int registeredCompatsCount()
@@ -220,7 +221,8 @@ public class ProtectionCompatManager implements Listener
         if (fakePlayer == null)
             return CompletableFuture.completedFuture("InvalidFakePlayer");
 
-        return checkForPlayer(fakePlayer, () -> function.apply(fakePlayer));
+        return checkForPlayer(fakePlayer, () -> function.apply(fakePlayer))
+            .exceptionally(throwable -> Util.exceptionally(throwable, "ERROR"));
     }
 
     /**

--- a/core/src/main/java/nl/pim16aap2/bigDoors/compatibility/ProtectionCompatManager.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/compatibility/ProtectionCompatManager.java
@@ -12,13 +12,14 @@ import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
@@ -34,7 +35,7 @@ public class ProtectionCompatManager implements Listener
     private static final String BYPASS_PERMISSION = "bigdoors.admin.bypasscompat";
 
     private final Map<String, IProtectionCompatDefinition> registeredDefinitions;
-    private final ArrayList<IProtectionCompat> protectionCompats;
+    private final List<IProtectionCompat> protectionCompats;
     private final FakePlayerCreator fakePlayerCreator;
     private final BigDoors plugin;
 
@@ -49,7 +50,7 @@ public class ProtectionCompatManager implements Listener
         this.plugin = plugin;
         registeredDefinitions = registerDefaultProtectionCompatDefinitions();
         fakePlayerCreator = plugin.getFakePlayerCreator();
-        protectionCompats = new ArrayList<>();
+        protectionCompats = new CopyOnWriteArrayList<>();
         restart();
     }
 
@@ -174,19 +175,22 @@ public class ProtectionCompatManager implements Listener
                 {
                     e.printStackTrace();
                     Thread.currentThread().interrupt();
-                    return "ERROR";
                 }
                 catch (TimeoutException e)
                 {
-                    plugin.getMyLogger().severe("Timed out checking permissions for offline player: " + fakePlayer);
-                    throw new RuntimeException(e);
+                    plugin.getMyLogger().log("Timed out checking permissions for offline player: " + fakePlayer, e);
                 }
                 catch (Exception e)
                 {
-                    plugin.getMyLogger().severe("Failed to check permissions for offline player: " + fakePlayer);
-                    throw new RuntimeException(e);
+                    plugin.getMyLogger().log("Failed to check permissions for offline player: " + fakePlayer, e);
                 }
+                return "ERROR";
             });
+    }
+
+    public int registeredCompatsCount()
+    {
+        return protectionCompats.size();
     }
 
     /**

--- a/core/src/main/java/nl/pim16aap2/bigDoors/compatibility/ProtectionCompatManager.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/compatibility/ProtectionCompatManager.java
@@ -4,22 +4,24 @@ import nl.pim16aap2.bigDoors.BigDoors;
 import nl.pim16aap2.bigDoors.util.Util;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import java.util.logging.Level;
 
 /**
@@ -39,7 +41,8 @@ public class ProtectionCompatManager implements Listener
     /**
      * Constructor of {@link ProtectionCompatManager}.
      *
-     * @param plugin The instance of {@link BigDoors}.
+     * @param plugin
+     *     The instance of {@link BigDoors}.
      */
     public ProtectionCompatManager(final BigDoors plugin)
     {
@@ -63,89 +66,52 @@ public class ProtectionCompatManager implements Listener
     }
 
     /**
-     * Check if a player is allowed to bypass the compatibility checks. Players can
-     * bypass the check if they are OP or if they have the
-     * {@link ProtectionCompatManager#BYPASS_PERMISSION} permission node.
+     * Check if a player is allowed to bypass the compatibility checks. Players can bypass the check if they are OP or
+     * if they have the {@link ProtectionCompatManager#BYPASS_PERMISSION} permission node.
      *
-     * @param player The {@link Player} to check the permissions for.
+     * @param player
+     *     The {@link Player} to check the permissions for.
      * @return True if the player can bypass the checks.
      */
-    private boolean canByPass(Player player)
+    private CompletableFuture<Boolean> canBypass(Player player)
     {
         if (player.isOp())
-            return true;
+            return CompletableFuture.completedFuture(true);
 
-        // offline players don't have permissions, so use Vault if that's the case.
+        // Real players do not have the FAKE_PLAYER tag, so we can use the real permissions check for them.
         if (!player.hasMetadata(FakePlayerCreator.FAKE_PLAYER_METADATA))
-            return player.hasPermission(BYPASS_PERMISSION);
-        return offlinePlayerHasPermission(player, player.getWorld().getName());
+            return CompletableFuture.completedFuture(player.hasPermission(BYPASS_PERMISSION));
+
+        // offline players don't have permissions, so use Vault to read those.
+        return plugin.getVaultManager().hasPermission(player, BYPASS_PERMISSION, player.getWorld().getName());
     }
 
     /**
-     * Circuitous way of checking if an offline player has a given permission in a
-     * given world or not.
+     * Get an online player from a player {@link UUID} in a given world. If the player with the given UUID is not
+     * online, a fake-online player is created.
      *
-     * @param oPlayer The offline player to check.
-     * @param world   The world to check the permission in.
-     * @return The if the player has the bypass permission node in this world.
-     */
-    private boolean offlinePlayerHasPermission(OfflinePlayer oPlayer, String world)
-    {
-        try
-        {
-            CompletableFuture<Boolean> future = CompletableFuture
-                .supplyAsync(() -> plugin.getVaultManager().hasPermission(oPlayer, BYPASS_PERMISSION, world));
-
-            return future.get();
-        }
-        catch (InterruptedException | ExecutionException e)
-        {
-            e.printStackTrace();
-        }
-        return false;
-    }
-
-    /**
-     * Get an online player from a player {@link UUID} in a given world. If the
-     * player with the given UUID is not online, a fake-online player is created.
-     *
-     * @param playerUUID The {@link UUID} of the player to get.
-     * @param playerName The name of the player. Used in case the player isn't
-     *                   online.
-     * @param world      The {@link World} the player is in.
+     * @param playerUUID
+     *     The {@link UUID} of the player to get.
+     * @param playerName
+     *     The name of the player. Used in case the player isn't online.
+     * @param world
+     *     The {@link World} the player is in.
      * @return An online {@link Player}. Either fake or real.
+     *
      * @see FakePlayerCreator
      */
     private @Nullable Player getPlayer(UUID playerUUID, String playerName, World world)
     {
-        Player player = Bukkit.getPlayer(playerUUID);
-        if (player == null)
-            player = fakePlayerCreator.getFakePlayer(Bukkit.getOfflinePlayer(playerUUID), playerName, world);
-        return player;
+        final Player player = Bukkit.getPlayer(playerUUID);
+        if (player != null)
+            return player;
+
+        return fakePlayerCreator.getFakePlayer(Bukkit.getOfflinePlayer(playerUUID), playerName, world);
     }
 
-    /**
-     * Check if a player can break a block at a given location.
-     *
-     * @param playerUUID The {@link UUID} of the player to check for.
-     * @param playerName The name of the player. Used in case the player isn't
-     *                   online.
-     * @param loc        The {@link Location} to check.
-     * @return The name of the {@link IProtectionCompat} that objects, if any, or
-     *         null if allowed by all compats.
-     */
-    public String canBreakBlock(UUID playerUUID, String playerName, Location loc)
+    // Needs to be called from the main thread!
+    private @Nullable String canBreakBlockSync(Player fakePlayer, Location loc)
     {
-        if (protectionCompats.isEmpty())
-            return null;
-
-        final @Nullable Player fakePlayer = getPlayer(playerUUID, playerName, loc.getWorld());
-        if (fakePlayer == null)
-            return "InvalidFakePlayer";
-
-        if (canByPass(fakePlayer))
-            return null;
-
         for (IProtectionCompat compat : protectionCompats)
             try
             {
@@ -155,38 +121,16 @@ public class ProtectionCompatManager implements Listener
             catch (Exception e)
             {
                 plugin.getMyLogger()
-                    .warn("Failed to use \"" + compat.getName() + "\"! Please send this error to pim16aap2:");
+                      .warn("Failed to use \"" + compat.getName() + "\"! Please send this error to pim16aap2:");
                 e.printStackTrace();
                 plugin.getMyLogger().logMessageToLogFile(compat.getName() + "\n" + Util.throwableToString(e));
             }
         return null;
     }
 
-    /**
-     * Check if a player can break all blocks between two locations.
-     *
-     * @param playerUUID The {@link UUID} of the player to check for.
-     * @param playerName The name of the player. Used in case the player isn't
-     *                   online.
-     * @param loc1       The start {@link Location} to check.
-     * @param loc2       The end {@link Location} to check.
-     * @return The name of the {@link IProtectionCompat} that objects, if any, or null if allowed by all compats.
-     */
-    public String canBreakBlocksBetweenLocs(UUID playerUUID, String playerName, World world, Location loc1,
-                                            Location loc2)
+    // Needs to be called from the main thread!
+    private @Nullable String canBreakBlocksBetweenLocsSync(Player fakePlayer, World world, Location loc1, Location loc2)
     {
-        if (protectionCompats.isEmpty())
-            return null;
-
-        final @Nullable Player fakePlayer = getPlayer(playerUUID, playerName, world);
-        if (fakePlayer == null)
-            return "InvalidFakePlayer";
-
-        if (canByPass(fakePlayer))
-            return null;
-        if (protectionCompats.isEmpty())
-            return null;
-
         loc1 = loc1.clone();
         loc2 = loc2.clone();
 
@@ -211,10 +155,112 @@ public class ProtectionCompatManager implements Listener
         return null;
     }
 
+    private CompletableFuture<@Nullable String> checkForPlayer(Player fakePlayer, Callable<@Nullable String> callable)
+    {
+        return canBypass(fakePlayer).thenApplyAsync(
+            canBypass ->
+            {
+                if (canBypass)
+                    return null;
+
+                try
+                {
+                    return Bukkit
+                        .getScheduler()
+                        .callSyncMethod(plugin, callable)
+                        .get(1, TimeUnit.SECONDS);
+                }
+                catch (InterruptedException e)
+                {
+                    e.printStackTrace();
+                    Thread.currentThread().interrupt();
+                    return "ERROR";
+                }
+                catch (TimeoutException e)
+                {
+                    plugin.getMyLogger().severe("Timed out checking permissions for offline player: " + fakePlayer);
+                    throw new RuntimeException(e);
+                }
+                catch (Exception e)
+                {
+                    plugin.getMyLogger().severe("Failed to check permissions for offline player: " + fakePlayer);
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    /**
+     * Checks something for a player. This can be used to, for example, check if a (fake) player has access to a
+     * location.
+     *
+     * @param playerUUID
+     *     The UUID of the player.
+     * @param playerName
+     *     The name of the player.
+     * @param world
+     *     The world in which to check the function.
+     * @param function
+     *     A function that accept a player and returns a String or null. The player argument may either be a real player
+     *     or a fake player created by {@link #fakePlayerCreator}.
+     * @return The future result of the function. If no hooks are registered with {@link #protectionCompats} the future
+     * will always contain 'null'. If at least one hook fails the test for the provided user, the name of that hook will
+     * be returned.
+     */
+    private CompletableFuture<@Nullable String> checkForPlayer(
+        UUID playerUUID, String playerName, World world, Function<Player, @Nullable String> function)
+    {
+        if (protectionCompats.isEmpty())
+            return CompletableFuture.completedFuture(null);
+
+        final @Nullable Player fakePlayer = getPlayer(playerUUID, playerName, world);
+        if (fakePlayer == null)
+            return CompletableFuture.completedFuture("InvalidFakePlayer");
+
+        return checkForPlayer(fakePlayer, () -> function.apply(fakePlayer));
+    }
+
+    /**
+     * Check if a player can break a block at a given location.
+     *
+     * @param playerUUID
+     *     The {@link UUID} of the player to check for.
+     * @param playerName
+     *     The name of the player. Used in case the player isn't online.
+     * @param loc
+     *     The {@link Location} to check.
+     * @return The name of the {@link IProtectionCompat} that objects, if any, or null if allowed by all compats.
+     */
+    public CompletableFuture<@Nullable String> canBreakBlock(UUID playerUUID, String playerName, Location loc)
+    {
+        return checkForPlayer(
+            playerUUID, playerName, loc.getWorld(), fakePlayer -> canBreakBlockSync(fakePlayer, loc));
+    }
+
+    /**
+     * Check if a player can break all blocks between two locations.
+     *
+     * @param playerUUID
+     *     The {@link UUID} of the player to check for.
+     * @param playerName
+     *     The name of the player. Used in case the player isn't online.
+     * @param loc1
+     *     The start {@link Location} to check.
+     * @param loc2
+     *     The end {@link Location} to check.
+     * @return The name of the {@link IProtectionCompat} that objects, if any, or null if allowed by all compats.
+     */
+    public CompletableFuture<@Nullable String> canBreakBlocksBetweenLocs(
+        UUID playerUUID, String playerName, World world, Location loc1, Location loc2)
+    {
+        return checkForPlayer(
+            playerUUID, playerName, world, fakePlayer -> canBreakBlocksBetweenLocsSync(fakePlayer, world, loc1, loc2));
+    }
+
     /**
      * Check if an {@link IProtectionCompat} is already loaded.
      *
-     * @param compatClass The class of the {@link IProtectionCompat} to check.
+     * @param compatClass
+     *     The class of the {@link IProtectionCompat} to check.
      * @return True if the compat has already been loaded.
      */
     private boolean protectionAlreadyLoaded(Class<? extends IProtectionCompat> compatClass)
@@ -226,10 +272,10 @@ public class ProtectionCompatManager implements Listener
     }
 
     /**
-     * Add a {@link IProtectionCompat} to the list of loaded compats if it loaded
-     * successfully.
+     * Add a {@link IProtectionCompat} to the list of loaded compats if it loaded successfully.
      *
-     * @param hook The compat to add.
+     * @param hook
+     *     The compat to add.
      */
     private void addProtectionCompat(IProtectionCompat hook)
     {
@@ -245,7 +291,8 @@ public class ProtectionCompatManager implements Listener
     /**
      * Load a compat for the plugin enabled in the event if needed.
      *
-     * @param event The event of the plugin that is loaded.
+     * @param event
+     *     The event of the plugin that is loaded.
      */
     @EventHandler
     protected void onPluginEnable(final PluginEnableEvent event)
@@ -256,7 +303,8 @@ public class ProtectionCompatManager implements Listener
     /**
      * Load a compat for a plugin with a given name if allowed and possible.
      *
-     * @param compatName The name of the plugin to load a compat for.
+     * @param compatName
+     *     The name of the plugin to load a compat for.
      */
     private void loadFromPluginName(final String compatName)
     {

--- a/core/src/main/java/nl/pim16aap2/bigDoors/handlers/CommandHandler.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/handlers/CommandHandler.java
@@ -92,7 +92,7 @@ public class CommandHandler implements CommandExecutor
             final CompletableFuture<DoorOpenResult> futureResult =
                 opener == null ?
                 CompletableFuture.completedFuture(DoorOpenResult.TYPEDISABLED) :
-                opener.openDoor(newDoor, time, instant);
+                opener.openDoorFuture(newDoor, time, instant);
 
             futureResult.thenAccept(
                 result ->

--- a/core/src/main/java/nl/pim16aap2/bigDoors/handlers/RedstoneHandler.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/handlers/RedstoneHandler.java
@@ -3,7 +3,6 @@ package nl.pim16aap2.bigDoors.handlers;
 import nl.pim16aap2.bigDoors.BigDoors;
 import nl.pim16aap2.bigDoors.Door;
 import nl.pim16aap2.bigDoors.util.ConfigLoader;
-import nl.pim16aap2.bigDoors.util.DoorOpenResult;
 import nl.pim16aap2.bigDoors.util.Util;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -20,11 +19,11 @@ public class RedstoneHandler implements Listener
         this.plugin = plugin;
     }
 
-    public boolean checkDoor(Location loc)
+    public void checkDoor(Location loc)
     {
         Door door = plugin.getCommander().doorFromPowerBlockLoc(loc);
-        return door != null && !door.isLocked() &&
-               plugin.getDoorOpener(door.getType()).openDoor(door, 0.0, false, true) == DoorOpenResult.SUCCESS;
+        if (door != null && !door.isLocked())
+            plugin.getDoorOpener(door.getType()).openDoor(door, 0.0, false, true).exceptionally(Util::exceptionally);
     }
 
     // When redstone changes, check if there's a power block on any side of it (just
@@ -70,7 +69,6 @@ public class RedstoneHandler implements Listener
         {
             plugin.getMyLogger().logMessage("Exception thrown while handling redstone event!", true, false);
             plugin.getMyLogger().logMessageToLogFile(Util.throwableToString(e));
-            BigDoors.get().getConfigLoader();
             if (ConfigLoader.DEBUG)
                 e.printStackTrace();
         }

--- a/core/src/main/java/nl/pim16aap2/bigDoors/handlers/RedstoneHandler.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/handlers/RedstoneHandler.java
@@ -23,7 +23,7 @@ public class RedstoneHandler implements Listener
     {
         Door door = plugin.getCommander().doorFromPowerBlockLoc(loc);
         if (door != null && !door.isLocked())
-            plugin.getDoorOpener(door.getType()).openDoor(door, 0.0, false, true).exceptionally(Util::exceptionally);
+            plugin.getDoorOpener(door.getType()).openDoorFuture(door, 0.0, false, true).exceptionally(Util::exceptionally);
     }
 
     // When redstone changes, check if there's a power block on any side of it (just

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/BridgeOpener.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/BridgeOpener.java
@@ -326,7 +326,7 @@ public class BridgeOpener implements Opener
     }
 
     @Override
-    public @Nonnull CompletableFuture<DoorOpenResult> openDoor(
+    public @Nonnull CompletableFuture<DoorOpenResult> openDoorFuture(
         @Nonnull Door door, double time, boolean instantOpen, boolean silent,
         @Nonnull ChunkLoadMode mode, boolean bypassProtectionHooks)
     {

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/BridgeOpener.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/BridgeOpener.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 public class BridgeOpener implements Opener
@@ -324,14 +326,15 @@ public class BridgeOpener implements Opener
     }
 
     @Override
-    public @Nonnull DoorOpenResult openDoor(@Nonnull Door door, double time, boolean instantOpen, boolean silent,
-                                            @Nonnull ChunkLoadMode mode, boolean bypassProtectionHooks)
+    public @Nonnull CompletableFuture<DoorOpenResult> openDoor(
+        @Nonnull Door door, double time, boolean instantOpen, boolean silent,
+        @Nonnull ChunkLoadMode mode, boolean bypassProtectionHooks)
     {
         if (!plugin.getCommander().canGo())
         {
             plugin.getMyLogger()
                   .info("Failed to toggle: " + door.toSimpleString() + ", as door toggles are currently disabled!");
-            return abort(DoorOpenResult.ERROR, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.ERROR, door.getDoorUID()));
         }
 
         if (plugin.getCommander().isDoorBusyRegisterIfNot(door.getDoorUID()))
@@ -339,7 +342,7 @@ public class BridgeOpener implements Opener
             if (!silent)
                 plugin.getMyLogger().myLogger(Level.INFO,
                                               "Bridge " + door.toSimpleString() + " is not available right now!");
-            return abort(DoorOpenResult.BUSY, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.BUSY, door.getDoorUID()));
         }
 
         final ChunkLoadResult chunkLoadResult = chunksLoaded(door, mode);
@@ -347,7 +350,7 @@ public class BridgeOpener implements Opener
         {
             plugin.getMyLogger().logMessage("Chunks for bridge " + door.toSimpleString() + " are not loaded!", true,
                                             false);
-            return abort(DoorOpenResult.CHUNKSNOTLOADED, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.CHUNKSNOTLOADED, door.getDoorUID()));
         }
         if (chunkLoadResult == ChunkLoadResult.REQUIRED_LOAD)
             instantOpen = true;
@@ -357,7 +360,7 @@ public class BridgeOpener implements Opener
         {
             plugin.getMyLogger().logMessage("Current direction is null for bridge " + door.toSimpleString() + "!", true,
                                             false);
-            return abort(DoorOpenResult.ERROR, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.ERROR, door.getDoorUID()));
         }
 
         RotateDirection upDown = getUpDown(door);
@@ -365,14 +368,14 @@ public class BridgeOpener implements Opener
         {
             plugin.getMyLogger().logMessage("UpDown direction is null for bridge " + door.toSimpleString() + "!", true,
                                             false);
-            return abort(DoorOpenResult.ERROR, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.ERROR, door.getDoorUID()));
         }
 
         final OpeningSpecification openingSpecification = getOpeningSpecification(door, upDown, currentDirection);
         if (openingSpecification == null)
         {
             plugin.getMyLogger().warn("Could not determine opening direction for door: " + door + "!");
-            return abort(DoorOpenResult.NODIRECTION, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.NODIRECTION, door.getDoorUID()));
         }
 
         if (!isRotateDirectionValid(door))
@@ -395,17 +398,31 @@ public class BridgeOpener implements Opener
         int maxDoorSize = getSizeLimit(door);
         if (maxDoorSize > 0 && door.getBlockCount() > maxDoorSize)
         {
-            plugin.getMyLogger().logMessage("Door " + door.toSimpleString() + " Exceeds the size limit: " + maxDoorSize,
-                                            true, false);
-            return abort(DoorOpenResult.ERROR, door.getDoorUID());
+            plugin.getMyLogger().logMessage(
+                "Door " + door.toSimpleString() + " Exceeds the size limit: " + maxDoorSize, true, false);
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.ERROR, door.getDoorUID()));
         }
 
-        if (!bypassProtectionHooks && !hasAccessToLocations(door, openingSpecification.min, openingSpecification.max))
-            return abort(DoorOpenResult.NOPERMISSION, door.getDoorUID());
-
         if (fireDoorEventTogglePrepare(door, instantOpen))
-            return abort(DoorOpenResult.CANCELLED, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.CANCELLED, door.getDoorUID()));
 
+        if (bypassProtectionHooks)
+            return CompletableFuture.completedFuture(openDoor0(door, time, upDown, instantOpen, openingSpecification));
+
+        final boolean instantOpen0 = instantOpen;
+        return hasAccessToLocations(door, openingSpecification.min, openingSpecification.max).thenCompose(
+            hasAccess ->
+            {
+                if (!hasAccess)
+                    return CompletableFuture.completedFuture(abort(DoorOpenResult.NOPERMISSION, door.getDoorUID()));
+                return Util.runSync(() -> openDoor0(door, time, upDown, instantOpen0, openingSpecification),
+                                    1, TimeUnit.SECONDS, DoorOpenResult.ERROR);
+            }).exceptionally(throwable -> Util.exceptionally(throwable, DoorOpenResult.ERROR));
+    }
+
+    private DoorOpenResult openDoor0(
+        Door door, double time, RotateDirection upDown, boolean instantOpen, OpeningSpecification openingSpecification)
+    {
         plugin.getCommander().addBlockMover(new BridgeMover(plugin, door.getWorld(), time, door, upDown,
                                                             openingSpecification.openDirection, instantOpen,
                                                             plugin.getConfigLoader().dbMultiplier()));

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/DoorOpener.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/DoorOpener.java
@@ -255,7 +255,7 @@ public class DoorOpener implements Opener
     }
 
     @Override
-    public @Nonnull CompletableFuture<DoorOpenResult> openDoor(
+    public @Nonnull CompletableFuture<DoorOpenResult> openDoorFuture(
         @Nonnull Door door, double time, boolean instantOpen, boolean silent,
         @Nonnull ChunkLoadMode mode, boolean bypassProtectionHooks)
     {

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/DoorOpener.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/DoorOpener.java
@@ -9,6 +9,7 @@ import nl.pim16aap2.bigDoors.util.DoorDirection;
 import nl.pim16aap2.bigDoors.util.DoorOpenResult;
 import nl.pim16aap2.bigDoors.util.Pair;
 import nl.pim16aap2.bigDoors.util.RotateDirection;
+import nl.pim16aap2.bigDoors.util.Util;
 import nl.pim16aap2.bigDoors.util.Vector2D;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -19,6 +20,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 public class DoorOpener implements Opener
@@ -252,14 +255,15 @@ public class DoorOpener implements Opener
     }
 
     @Override
-    public @Nonnull DoorOpenResult openDoor(@Nonnull Door door, double time, boolean instantOpen, boolean silent,
-                                            @Nonnull ChunkLoadMode mode, boolean bypassProtectionHooks)
+    public @Nonnull CompletableFuture<DoorOpenResult> openDoor(
+        @Nonnull Door door, double time, boolean instantOpen, boolean silent,
+        @Nonnull ChunkLoadMode mode, boolean bypassProtectionHooks)
     {
         if (!plugin.getCommander().canGo())
         {
             plugin.getMyLogger()
                   .info("Failed to toggle: " + door.toSimpleString() + ", as door toggles are currently disabled!");
-            return abort(DoorOpenResult.ERROR, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.ERROR, door.getDoorUID()));
         }
 
         if (plugin.getCommander().isDoorBusyRegisterIfNot(door.getDoorUID()))
@@ -267,7 +271,7 @@ public class DoorOpener implements Opener
             if (!silent)
                 plugin.getMyLogger().myLogger(Level.INFO,
                                               "Door " + door.toSimpleString() + " is not available right now!");
-            return abort(DoorOpenResult.BUSY, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.BUSY, door.getDoorUID()));
         }
 
         final ChunkLoadResult chunkLoadResult = chunksLoaded(door, mode);
@@ -275,7 +279,7 @@ public class DoorOpener implements Opener
         {
             plugin.getMyLogger().logMessage("Chunks for door " + door.toSimpleString() + " are not loaded!", true,
                                             false);
-            return abort(DoorOpenResult.CHUNKSNOTLOADED, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.CHUNKSNOTLOADED, door.getDoorUID()));
         }
         if (chunkLoadResult == ChunkLoadResult.REQUIRED_LOAD)
             instantOpen = true;
@@ -285,7 +289,7 @@ public class DoorOpener implements Opener
         {
             plugin.getMyLogger().logMessage("Current direction is null for door " + door.toSimpleString() + "!", true,
                                             false);
-            return abort(DoorOpenResult.ERROR, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.ERROR, door.getDoorUID()));
         }
 
         final OpeningSpecification openingSpecification = getOpeningSpecification(door, getOpenDirection(door),
@@ -293,7 +297,7 @@ public class DoorOpener implements Opener
         if (openingSpecification == null)
         {
             plugin.getMyLogger().warn("Could not determine opening direction for door: " + door + "!");
-            return abort(DoorOpenResult.NODIRECTION, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.NODIRECTION, door.getDoorUID()));
         }
 
         if (!isRotateDirectionValid(door))
@@ -341,15 +345,32 @@ public class DoorOpener implements Opener
         {
             plugin.getMyLogger().logMessage("Door " + door.toSimpleString() + " Exceeds the size limit: " + maxDoorSize,
                                             true, false);
-            return abort(DoorOpenResult.ERROR, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.ERROR, door.getDoorUID()));
         }
 
-        if (!bypassProtectionHooks && !hasAccessToLocations(door, openingSpecification.min, openingSpecification.max))
-            return abort(DoorOpenResult.NOPERMISSION, door.getDoorUID());
-
         if (fireDoorEventTogglePrepare(door, instantOpen))
-            return abort(DoorOpenResult.CANCELLED, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.CANCELLED, door.getDoorUID()));
 
+        if (bypassProtectionHooks)
+            return CompletableFuture.completedFuture(
+                openDoor0(door, oppositePoint, openingSpecification, time, instantOpen, currentDirection));
+
+        final boolean instantOpen0 = instantOpen;
+        return hasAccessToLocations(door, openingSpecification.min, openingSpecification.max).thenCompose(
+            hasAccess ->
+            {
+                if (!hasAccess)
+                    return CompletableFuture.completedFuture(abort(DoorOpenResult.NOPERMISSION, door.getDoorUID()));
+                return Util.runSync(() -> openDoor0(door, oppositePoint, openingSpecification,
+                                                    time, instantOpen0, currentDirection),
+                                    1, TimeUnit.SECONDS, DoorOpenResult.ERROR);
+            }).exceptionally(throwable -> Util.exceptionally(throwable, DoorOpenResult.ERROR));
+    }
+
+    private DoorOpenResult openDoor0(
+        Door door, Location oppositePoint, DoorOpener.OpeningSpecification openingSpecification, double time,
+        boolean instantOpen, DoorDirection currentDirection)
+    {
         plugin.getCommander()
               .addBlockMover(
                   new CylindricalMover(plugin, oppositePoint.getWorld(), 1, openingSpecification.rotateDirection, time,

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/Opener.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/Opener.java
@@ -21,12 +21,13 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 public interface Opener
 {
@@ -77,33 +78,41 @@ public interface Opener
      * @param bypassProtectionHooks Whether to bypass the protection hooks when trying to toggle the door.
      * @return The result of the toggle attempt.
      */
-    default @Nonnull DoorOpenResult openDoor(@Nonnull Door door, boolean bypassProtectionHooks)
+    default @NotNull CompletableFuture<DoorOpenResult> openDoor(
+        @NotNull Door door, boolean bypassProtectionHooks)
     {
-        return openDoor(door, 0.0, false, false, getChunkLoadMode(door), bypassProtectionHooks);
+        return openDoor(door, 0.0, false, false, getChunkLoadMode(door), bypassProtectionHooks)
+            .exceptionally(throwable -> Util.exceptionally(throwable, DoorOpenResult.ERROR));
     }
 
     /**
      * See {@link #openDoor(Door, double, boolean, boolean, ChunkLoadMode, boolean)}.
      */
-    default @Nonnull DoorOpenResult openDoor(@Nonnull Door door, double time)
+    default @NotNull CompletableFuture<DoorOpenResult> openDoor(
+        @NotNull Door door, double time)
     {
-        return openDoor(door, time, false, false);
+        return openDoor(door, time, false, false)
+            .exceptionally(throwable -> Util.exceptionally(throwable, DoorOpenResult.ERROR));
     }
 
     /**
      * See {@link #openDoor(Door, double, boolean, boolean, ChunkLoadMode, boolean)}.
      */
-    default @Nonnull DoorOpenResult openDoor(@Nonnull Door door, double time, boolean instantOpen)
+    default @NotNull CompletableFuture<DoorOpenResult> openDoor(
+        @NotNull Door door, double time, boolean instantOpen)
     {
-        return openDoor(door, time, instantOpen, false);
+        return openDoor(door, time, instantOpen, false)
+            .exceptionally(throwable -> Util.exceptionally(throwable, DoorOpenResult.ERROR));
     }
 
     /**
      * See {@link #openDoor(Door, double, boolean, boolean, ChunkLoadMode, boolean)}.
      */
-    default @Nonnull DoorOpenResult openDoor(@Nonnull Door door, double time, boolean instantOpen, boolean silent)
+    default @NotNull CompletableFuture<DoorOpenResult> openDoor(
+        @NotNull Door door, double time, boolean instantOpen, boolean silent)
     {
-        return openDoor(door, time, instantOpen, silent, getChunkLoadMode(door));
+        return openDoor(door, time, instantOpen, silent, getChunkLoadMode(door))
+            .exceptionally(throwable -> Util.exceptionally(throwable, DoorOpenResult.ERROR));
     }
 
     /**
@@ -114,7 +123,7 @@ public interface Opener
      * @param door The door for which to get the {@link ChunkLoadMode}.
      * @return The {@link ChunkLoadMode} to use for the door.
      */
-    default @Nonnull ChunkLoadMode getChunkLoadMode(@Nonnull Door door)
+    default @NotNull ChunkLoadMode getChunkLoadMode(@NotNull Door door)
     {
         ChunkLoadMode mode = BigDoors.get().getConfigLoader().getChunkLoadMode();
 
@@ -130,10 +139,11 @@ public interface Opener
     /**
      * See {@link #openDoor(Door, double, boolean, boolean, ChunkLoadMode, boolean)}.
      */
-    default @Nonnull DoorOpenResult openDoor(@Nonnull Door door, double time, boolean instantOpen, boolean silent,
-                                             @Nonnull ChunkLoadMode mode)
+    default @NotNull CompletableFuture<DoorOpenResult> openDoor(
+        @NotNull Door door, double time, boolean instantOpen, boolean silent, @NotNull ChunkLoadMode mode)
     {
-        return openDoor(door, time, instantOpen, silent, mode, false);
+        return openDoor(door, time, instantOpen, silent, mode, false)
+            .exceptionally(throwable -> Util.exceptionally(throwable, DoorOpenResult.ERROR));
     }
 
     /**
@@ -152,8 +162,9 @@ public interface Opener
      * @param bypassProtectionHooks Whether to bypass the protection hooks when trying to toggle the door.
      * @return The result of the toggle attempt.
      */
-    @Nonnull DoorOpenResult openDoor(@Nonnull Door door, double time, boolean instantOpen, boolean silent,
-                                     @Nonnull ChunkLoadMode mode, boolean bypassProtectionHooks);
+    @NotNull CompletableFuture<DoorOpenResult> openDoor(
+        @NotNull Door door, double time, boolean instantOpen, boolean silent,
+        @NotNull ChunkLoadMode mode, boolean bypassProtectionHooks);
 
     default DoorOpenResult abort(DoorOpenResult reason, long doorUID)
     {
@@ -194,7 +205,7 @@ public interface Opener
         return getValidRotateDirections().contains(rotateDirection);
     }
 
-    default boolean isRotateDirectionValid(@Nonnull Door door)
+    default boolean isRotateDirectionValid(@NotNull Door door)
     {
         return isValidOpenDirection(door.getOpenDir());
     }
@@ -223,7 +234,7 @@ public interface Opener
      * @return The new minimum and maximum coordinates the door would take up if it were toggled now.
      */
     @SuppressWarnings("unused")
-    @Nonnull Optional<Pair<Location, Location>> getNewCoordinates(@Nonnull Door door);
+    @NotNull Optional<Pair<Location, Location>> getNewCoordinates(@NotNull Door door);
 
     default int getSizeLimit(final Door door)
     {
@@ -245,7 +256,7 @@ public interface Opener
      * air). If any blocks are in the way or if the locations are out of range of the
      * {@link WorldHeightManager#getWorldHeightLimits(World)}, this method will return false.
      */
-    default boolean isPosFree(long doorUID, @Nonnull World world, @Nonnull Location min, @Nonnull Location max)
+    default boolean isPosFree(long doorUID, @NotNull World world, @NotNull Location min, @NotNull Location max)
     {
         final WorldHeightLimits worldLimits = BigDoors.get().getWorldHeightManager().getWorldHeightLimits(world);
         if (min.getBlockY() < worldLimits.getLowerLimit() || max.getBlockY() > worldLimits.getUpperLimit())
@@ -277,7 +288,7 @@ public interface Opener
      *
      * @param locations The min and max locations respectively.
      */
-    default boolean isPosFree(long doorUID, @Nonnull World world, @Nonnull Pair<Location, Location> locations)
+    default boolean isPosFree(long doorUID, @NotNull World world, @NotNull Pair<Location, Location> locations)
     {
         return isPosFree(doorUID, world, locations.first, locations.second);
     }
@@ -293,29 +304,42 @@ public interface Opener
      * @return True if the owner of the door has access to both the current area of the door and the new area of the
      * door.
      */
-    default boolean hasAccessToLocations(@Nonnull Door door, @Nonnull Location newMin, @Nonnull Location newMax)
+    default CompletableFuture<Boolean> hasAccessToLocations(
+        @NotNull Door door, @NotNull Location newMin, @NotNull Location newMax)
     {
-        String protectionBlocker = BigDoors.get().canBreakBlocksBetweenLocs(door.getPlayerUUID(), door.getPlayerName(),
-                                                                            door.getWorld(), newMin, newMax);
-        if (protectionBlocker != null)
-        {
-            BigDoors.get().getMyLogger().logMessageToLogFile(
-                "Toggle denied because access to new location was prevented by " + protectionBlocker + " for door: " +
-                    door);
-            return false;
-        }
+        if (BigDoors.get().getProtectionCompatManager().registeredCompatsCount() == 0)
+            return CompletableFuture.completedFuture(true);
 
-        protectionBlocker = BigDoors.get().canBreakBlocksBetweenLocs(door.getPlayerUUID(), door.getPlayerName(),
-                                                                     door.getWorld(), door.getMinimum(),
-                                                                     door.getMaximum());
-        if (protectionBlocker != null)
-        {
-            BigDoors.get().getMyLogger().logMessageToLogFile(
-                "Toggle denied because access to old location was prevented by " + protectionBlocker + " for door: " +
-                    door);
-            return false;
-        }
-        return true;
+        final CompletableFuture<@Nullable String> oldLoc =
+            BigDoors.get().canBreakBlocksBetweenLocs(
+                door.getPlayerUUID(), door.getPlayerName(), door.getWorld(), door.getMinimum(), door.getMaximum());
+
+        final CompletableFuture<@Nullable String> newLoc =
+            BigDoors.get().canBreakBlocksBetweenLocs(
+                door.getPlayerUUID(), door.getPlayerName(), door.getWorld(), newMin, newMax);
+
+        return Util.getAllCompletableFutureResults(oldLoc, newLoc).thenApply(
+            lst ->
+            {
+                final @Nullable String canBreakOldBlocks = lst.get(0);
+                if (canBreakOldBlocks != null)
+                {
+                    BigDoors.get().getMyLogger().logMessageToLogFile(
+                        "Toggle denied because access to new location was prevented by " + canBreakOldBlocks +
+                            " for door: " + door);
+                    return false;
+                }
+
+                final @Nullable String canBreakNewBlocks = lst.get(1);
+                if (canBreakNewBlocks != null)
+                {
+                    BigDoors.get().getMyLogger().logMessageToLogFile(
+                        "Toggle denied because access to old location was prevented by " + canBreakNewBlocks +
+                            " for door: " + door);
+                    return false;
+                }
+                return true;
+            }).exceptionally(throwable -> Util.exceptionally(throwable, false));
     }
 
     /**
@@ -349,5 +373,5 @@ public interface Opener
      *
      * @return A list with all valid {@link RotateDirection}s for this opener.
      */
-    @Nonnull List<RotateDirection> getValidRotateDirections();
+    @NotNull List<RotateDirection> getValidRotateDirections();
 }

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/Opener.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/Opener.java
@@ -24,6 +24,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -78,40 +79,40 @@ public interface Opener
      * @param bypassProtectionHooks Whether to bypass the protection hooks when trying to toggle the door.
      * @return The result of the toggle attempt.
      */
-    default @NotNull CompletableFuture<DoorOpenResult> openDoor(
+    default @NotNull CompletableFuture<DoorOpenResult> openDoorFuture(
         @NotNull Door door, boolean bypassProtectionHooks)
     {
-        return openDoor(door, 0.0, false, false, getChunkLoadMode(door), bypassProtectionHooks)
+        return openDoorFuture(door, 0.0, false, false, getChunkLoadMode(door), bypassProtectionHooks)
             .exceptionally(throwable -> Util.exceptionally(throwable, DoorOpenResult.ERROR));
     }
 
     /**
-     * See {@link #openDoor(Door, double, boolean, boolean, ChunkLoadMode, boolean)}.
+     * See {@link #openDoorFuture(Door, double, boolean, boolean, ChunkLoadMode, boolean)}.
      */
-    default @NotNull CompletableFuture<DoorOpenResult> openDoor(
+    default @NotNull CompletableFuture<DoorOpenResult> openDoorFuture(
         @NotNull Door door, double time)
     {
-        return openDoor(door, time, false, false)
+        return openDoorFuture(door, time, false, false)
             .exceptionally(throwable -> Util.exceptionally(throwable, DoorOpenResult.ERROR));
     }
 
     /**
-     * See {@link #openDoor(Door, double, boolean, boolean, ChunkLoadMode, boolean)}.
+     * See {@link #openDoorFuture(Door, double, boolean, boolean, ChunkLoadMode, boolean)}.
      */
-    default @NotNull CompletableFuture<DoorOpenResult> openDoor(
+    default @NotNull CompletableFuture<DoorOpenResult> openDoorFuture(
         @NotNull Door door, double time, boolean instantOpen)
     {
-        return openDoor(door, time, instantOpen, false)
+        return openDoorFuture(door, time, instantOpen, false)
             .exceptionally(throwable -> Util.exceptionally(throwable, DoorOpenResult.ERROR));
     }
 
     /**
-     * See {@link #openDoor(Door, double, boolean, boolean, ChunkLoadMode, boolean)}.
+     * See {@link #openDoorFuture(Door, double, boolean, boolean, ChunkLoadMode, boolean)}.
      */
-    default @NotNull CompletableFuture<DoorOpenResult> openDoor(
+    default @NotNull CompletableFuture<DoorOpenResult> openDoorFuture(
         @NotNull Door door, double time, boolean instantOpen, boolean silent)
     {
-        return openDoor(door, time, instantOpen, silent, getChunkLoadMode(door))
+        return openDoorFuture(door, time, instantOpen, silent, getChunkLoadMode(door))
             .exceptionally(throwable -> Util.exceptionally(throwable, DoorOpenResult.ERROR));
     }
 
@@ -137,12 +138,12 @@ public interface Opener
     }
 
     /**
-     * See {@link #openDoor(Door, double, boolean, boolean, ChunkLoadMode, boolean)}.
+     * See {@link #openDoorFuture(Door, double, boolean, boolean, ChunkLoadMode, boolean)}.
      */
-    default @NotNull CompletableFuture<DoorOpenResult> openDoor(
+    default @NotNull CompletableFuture<DoorOpenResult> openDoorFuture(
         @NotNull Door door, double time, boolean instantOpen, boolean silent, @NotNull ChunkLoadMode mode)
     {
-        return openDoor(door, time, instantOpen, silent, mode, false)
+        return openDoorFuture(door, time, instantOpen, silent, mode, false)
             .exceptionally(throwable -> Util.exceptionally(throwable, DoorOpenResult.ERROR));
     }
 
@@ -162,7 +163,7 @@ public interface Opener
      * @param bypassProtectionHooks Whether to bypass the protection hooks when trying to toggle the door.
      * @return The result of the toggle attempt.
      */
-    @NotNull CompletableFuture<DoorOpenResult> openDoor(
+    @NotNull CompletableFuture<DoorOpenResult> openDoorFuture(
         @NotNull Door door, double time, boolean instantOpen, boolean silent,
         @NotNull ChunkLoadMode mode, boolean bypassProtectionHooks);
 
@@ -177,7 +178,94 @@ public interface Opener
     }
 
     /**
-     * Gets the number of blocks between this door and the world limit
+     * Attempts to get the result stored in a CompletableFuture that contains a DoorOpenResult.
+     * </p>
+     * Because most steps of the toggle process are performed on the main thread, the resulting CompletableFuture will
+     * often contain the actual value.
+     * </p>
+     * However, in certain circumstances the CompletableFuture may actually include asynchronous steps. When this
+     * happens, this method is unable to retrieve the real value.
+     *
+     * @param result The future result of attempting to toggle a door.
+     * @return The DoorOpenResult in the {@link CompletableFuture} if it is available. When it is not (yet) available,
+     * {@link DoorOpenResult#ERROR} is returned instead.
+     */
+    static DoorOpenResult processFutureResult(CompletableFuture<DoorOpenResult> result)
+    {
+        return result.getNow(DoorOpenResult.ERROR);
+    }
+
+    /**
+     * @deprecated Use {@link #openDoorFuture(Door, double, boolean, boolean, ChunkLoadMode, boolean)} instead.
+     * </p>
+     * This method may not return to real result; see {@link #processFutureResult(CompletableFuture)}.
+     */
+    @Deprecated
+    default @Nonnull DoorOpenResult openDoor(
+        @Nonnull Door door, double time, boolean instantOpen, boolean silent, @Nonnull ChunkLoadMode mode,
+        boolean bypassProtectionHooks)
+    {
+        return processFutureResult(openDoorFuture(door, time, instantOpen, silent, mode, bypassProtectionHooks));
+    }
+
+    /**
+     * @deprecated Use {@link #openDoorFuture(Door, double, boolean, boolean, ChunkLoadMode)} instead.
+     * </p>
+     * This method may not return to real result; see {@link #processFutureResult(CompletableFuture)}.
+     */
+    @Deprecated
+    default @Nonnull DoorOpenResult openDoor(
+        @Nonnull Door door, double time, boolean instantOpen, boolean silent, @Nonnull ChunkLoadMode mode)
+    {
+        return openDoor(door, time, instantOpen, silent, mode, false);
+    }
+
+    /**
+     * @deprecated Use {@link #openDoorFuture(Door, boolean)} instead.
+     * </p>
+     * This method may not return to real result; see {@link #processFutureResult(CompletableFuture)}.
+     */
+    @Deprecated
+    default @Nonnull DoorOpenResult openDoor(@Nonnull Door door, boolean bypassProtectionHooks)
+    {
+        return openDoor(door, 0.0, false, false, getChunkLoadMode(door), bypassProtectionHooks);
+    }
+
+    /**
+     * @deprecated Use {@link #openDoorFuture(Door, double)} instead.
+     * </p>
+     * This method may not return to real result; see {@link #processFutureResult(CompletableFuture)}.
+     */
+    @Deprecated
+    default @Nonnull DoorOpenResult openDoor(@Nonnull Door door, double time)
+    {
+        return openDoor(door, time, false, false);
+    }
+
+    /**
+     * @deprecated Use {@link #openDoorFuture(Door, double, boolean)} instead.
+     * </p>
+     * This method may not return to real result; see {@link #processFutureResult(CompletableFuture)}.
+     */
+    @Deprecated
+    default @Nonnull DoorOpenResult openDoor(@Nonnull Door door, double time, boolean instantOpen)
+    {
+        return openDoor(door, time, instantOpen, false);
+    }
+
+    /**
+     * @deprecated Use {@link #openDoorFuture(Door, double, boolean, boolean)} instead.
+     * </p>
+     * This method may not return to real result; see {@link #processFutureResult(CompletableFuture)}.
+     */
+    @Deprecated
+    default @Nonnull DoorOpenResult openDoor(@Nonnull Door door, double time, boolean instantOpen, boolean silent)
+    {
+        return openDoor(door, time, instantOpen, silent, getChunkLoadMode(door));
+    }
+
+    /**
+     * Gets the number of blocks between this door and the world limit.
      *
      * @param door               The door for which to find the distances to the world limits.
      * @param worldHeightManager The world height manager.

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/PortcullisOpener.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/PortcullisOpener.java
@@ -90,7 +90,7 @@ public class PortcullisOpener implements Opener
     }
 
     @Override
-    public @Nonnull CompletableFuture<DoorOpenResult> openDoor(
+    public @Nonnull CompletableFuture<DoorOpenResult> openDoorFuture(
         @Nonnull Door door, double time, boolean instantOpen, boolean silent,
         @Nonnull ChunkLoadMode mode, boolean bypassProtectionHooks)
     {

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/SlidingDoorOpener.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/SlidingDoorOpener.java
@@ -18,6 +18,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 public class SlidingDoorOpener implements Opener
@@ -186,14 +188,15 @@ public class SlidingDoorOpener implements Opener
     }
 
     @Override
-    public @Nonnull DoorOpenResult openDoor(@Nonnull Door door, double time, boolean instantOpen, boolean silent,
-                                            @Nonnull ChunkLoadMode mode, boolean bypassProtectionHooks)
+    public @Nonnull CompletableFuture<DoorOpenResult> openDoor(
+        @Nonnull Door door, double time, boolean instantOpen, boolean silent,
+        @Nonnull ChunkLoadMode mode, boolean bypassProtectionHooks)
     {
         if (!plugin.getCommander().canGo())
         {
             plugin.getMyLogger()
                   .info("Failed to toggle: " + door.toSimpleString() + ", as door toggles are currently disabled!");
-            return abort(DoorOpenResult.ERROR, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.ERROR, door.getDoorUID()));
         }
 
         if (plugin.getCommander().isDoorBusyRegisterIfNot(door.getDoorUID()))
@@ -201,7 +204,7 @@ public class SlidingDoorOpener implements Opener
             if (!silent)
                 plugin.getMyLogger()
                       .myLogger(Level.INFO, "Sliding Door " + door.toSimpleString() + " is not available right now!");
-            return abort(DoorOpenResult.BUSY, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.BUSY, door.getDoorUID()));
         }
 
         final ChunkLoadResult chunkLoadResult = chunksLoaded(door, mode);
@@ -209,7 +212,7 @@ public class SlidingDoorOpener implements Opener
         {
             plugin.getMyLogger()
                   .logMessage("Chunks for sliding door " + door.toSimpleString() + " are not loaded!", true, false);
-            return abort(DoorOpenResult.CHUNKSNOTLOADED, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.CHUNKSNOTLOADED, door.getDoorUID()));
         }
         if (chunkLoadResult == ChunkLoadResult.REQUIRED_LOAD)
             instantOpen = true;
@@ -222,7 +225,7 @@ public class SlidingDoorOpener implements Opener
             plugin.getMyLogger()
                   .logMessage("Sliding Door " + door.toSimpleString() + " Exceeds the size limit: " + maxDoorSize,
                               true, false);
-            return abort(DoorOpenResult.ERROR, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.ERROR, door.getDoorUID()));
         }
 
         if (door.getBlocksToMove() > BigDoors.get().getConfigLoader().getMaxBlocksToMove())
@@ -230,13 +233,13 @@ public class SlidingDoorOpener implements Opener
             plugin.getMyLogger().logMessage("Sliding Door " + door.toSimpleString() + " Exceeds blocksToMove limit: "
                                                 + door.getBlocksToMove() + ". Limit = " +
                                                 BigDoors.get().getConfigLoader().getMaxBlocksToMove(), true, false);
-            return abort(DoorOpenResult.BLOCKSTOMOVEINVALID, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.BLOCKSTOMOVEINVALID, door.getDoorUID()));
         }
 
         final MovementSpecification blocksToMove = getBlocksToMove(door);
 
         if (blocksToMove.getBlocks() == 0)
-            return abort(DoorOpenResult.NODIRECTION, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.NODIRECTION, door.getDoorUID()));
 
         if (!isRotateDirectionValid(door))
         {
@@ -261,12 +264,25 @@ public class SlidingDoorOpener implements Opener
         Location newMax = door.getMaximum();
         getNewCoords(newMin, newMax, blocksToMove);
 
-        if (!bypassProtectionHooks && !hasAccessToLocations(door, newMin, newMax))
-            return abort(DoorOpenResult.NOPERMISSION, door.getDoorUID());
-
         if (fireDoorEventTogglePrepare(door, instantOpen))
-            return abort(DoorOpenResult.CANCELLED, door.getDoorUID());
+            return CompletableFuture.completedFuture(abort(DoorOpenResult.CANCELLED, door.getDoorUID()));
 
+        if (bypassProtectionHooks)
+            return CompletableFuture.completedFuture(openDoor0(door, time, instantOpen, blocksToMove));
+
+        final boolean instantOpen0 = instantOpen;
+        return hasAccessToLocations(door, newMin, newMax).thenCompose(
+            hasAccess ->
+            {
+                if (!hasAccess)
+                    return CompletableFuture.completedFuture(abort(DoorOpenResult.NOPERMISSION, door.getDoorUID()));
+                return Util.runSync(() -> openDoor0(door, time, instantOpen0, blocksToMove),
+                                    1, TimeUnit.SECONDS, DoorOpenResult.ERROR);
+            }).exceptionally(throwable -> Util.exceptionally(throwable, DoorOpenResult.ERROR));
+    }
+
+    private DoorOpenResult openDoor0(Door door, double time, boolean instantOpen, MovementSpecification blocksToMove)
+    {
         plugin.getCommander()
               .addBlockMover(new SlidingMover(plugin, door.getWorld(), time, door, instantOpen,
                                               blocksToMove.getBlocks(), blocksToMove.getRotateDirection(),

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/SlidingDoorOpener.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/SlidingDoorOpener.java
@@ -188,7 +188,7 @@ public class SlidingDoorOpener implements Opener
     }
 
     @Override
-    public @Nonnull CompletableFuture<DoorOpenResult> openDoor(
+    public @Nonnull CompletableFuture<DoorOpenResult> openDoorFuture(
         @Nonnull Door door, double time, boolean instantOpen, boolean silent,
         @Nonnull ChunkLoadMode mode, boolean bypassProtectionHooks)
     {

--- a/core/src/main/java/nl/pim16aap2/bigDoors/toolUsers/DoorCreator.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/toolUsers/DoorCreator.java
@@ -1,11 +1,12 @@
 package nl.pim16aap2.bigDoors.toolUsers;
 
-import org.bukkit.Location;
-import org.bukkit.entity.Player;
-
 import nl.pim16aap2.bigDoors.BigDoors;
 import nl.pim16aap2.bigDoors.util.DoorType;
 import nl.pim16aap2.bigDoors.util.Util;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * This class represents players in the process of creating doors. Objects of
@@ -87,16 +88,8 @@ public class DoorCreator extends ToolUser
         return xDepth == 0 ^ zDepth == 0;
     }
 
-    // Take care of the selection points.
-    @Override
-    public void selector(Location loc)
+    private void selector(Location loc, @Nullable String canBreakBlock)
     {
-        if (name == null)
-        {
-            Util.messagePlayer(player, messages.getString("CREATOR.GENERAL.GiveNameInstruc"));
-            return;
-        }
-        String canBreakBlock = plugin.canBreakBlock(player.getUniqueId(), player.getName(), loc);
         if (canBreakBlock != null)
         {
             Util.messagePlayer(player, messages.getString("CREATOR.GENERAL.NoPermissionHere") + " " + canBreakBlock);
@@ -137,5 +130,18 @@ public class DoorCreator extends ToolUser
         }
         else
             setIsDone(true);
+    }
+
+    // Take care of the selection points.
+    @Override
+    public void selector(Location loc)
+    {
+        if (name == null)
+        {
+            Util.messagePlayer(player, messages.getString("CREATOR.GENERAL.GiveNameInstruc"));
+            return;
+        }
+        plugin.canBreakBlock(player.getUniqueId(), player.getName(), loc)
+              .thenApply(canBreakBlock -> Bukkit.getScheduler().runTask(plugin, () -> selector(loc, canBreakBlock)));
     }
 }

--- a/core/src/main/java/nl/pim16aap2/bigDoors/toolUsers/DrawbridgeCreator.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/toolUsers/DrawbridgeCreator.java
@@ -1,14 +1,15 @@
 package nl.pim16aap2.bigDoors.toolUsers;
 
-import org.bukkit.Location;
-import org.bukkit.entity.Player;
-import org.bukkit.util.Vector;
-
 import nl.pim16aap2.bigDoors.BigDoors;
 import nl.pim16aap2.bigDoors.util.DoorDirection;
 import nl.pim16aap2.bigDoors.util.DoorType;
 import nl.pim16aap2.bigDoors.util.RotateDirection;
 import nl.pim16aap2.bigDoors.util.Util;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.Nullable;
 
 /*
  * This class represents players in the process of creating doors.
@@ -213,16 +214,8 @@ public class DrawbridgeCreator extends ToolUser
         return xDepth != 0 ^ zDepth != 0;
     }
 
-    // Take care of the selection points.
-    @Override
-    public void selector(Location loc)
+    private void selector(Location loc, @Nullable String canBreakBlock)
     {
-        if (name == null)
-        {
-            Util.messagePlayer(player, messages.getString("CREATOR.GENERAL.GiveNameInstruc"));
-            return;
-        }
-        String canBreakBlock = plugin.canBreakBlock(player.getUniqueId(), player.getName(), loc);
         if (canBreakBlock != null)
         {
             Util.messagePlayer(player, messages.getString("CREATOR.GENERAL.NoPermissionHere") + " " + canBreakBlock);
@@ -287,5 +280,18 @@ public class DrawbridgeCreator extends ToolUser
         }
         else
             setIsDone(true);
+    }
+
+    // Take care of the selection points.
+    @Override
+    public void selector(Location loc)
+    {
+        if (name == null)
+        {
+            Util.messagePlayer(player, messages.getString("CREATOR.GENERAL.GiveNameInstruc"));
+            return;
+        }
+        plugin.canBreakBlock(player.getUniqueId(), player.getName(), loc)
+              .thenApply(canBreakBlock -> Bukkit.getScheduler().runTask(plugin, () -> selector(loc, canBreakBlock)));
     }
 }

--- a/core/src/main/java/nl/pim16aap2/bigDoors/toolUsers/PortcullisCreator.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/toolUsers/PortcullisCreator.java
@@ -1,12 +1,13 @@
 package nl.pim16aap2.bigDoors.toolUsers;
 
-import org.bukkit.ChatColor;
-import org.bukkit.Location;
-import org.bukkit.entity.Player;
-
 import nl.pim16aap2.bigDoors.BigDoors;
 import nl.pim16aap2.bigDoors.util.DoorType;
 import nl.pim16aap2.bigDoors.util.Util;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
 
 public class PortcullisCreator extends ToolUser
 {
@@ -48,16 +49,8 @@ public class PortcullisCreator extends ToolUser
         engine = new Location(one.getWorld(), xMid, yMin, zMid);
     }
 
-    // Take care of the selection points.
-    @Override
-    public void selector(Location loc)
+    private void selector(Location loc, @Nullable String canBreakBlock)
     {
-        if (name == null)
-        {
-            Util.messagePlayer(player, messages.getString("CREATOR.GENERAL.GiveNameInstruc"));
-            return;
-        }
-        String canBreakBlock = plugin.canBreakBlock(player.getUniqueId(), player.getName(), loc);
         if (canBreakBlock != null)
         {
             Util.messagePlayer(player, messages.getString("CREATOR.GENERAL.NoPermissionHere") + " " + canBreakBlock);
@@ -78,5 +71,18 @@ public class PortcullisCreator extends ToolUser
             setEngine();
             setIsDone(true);
         }
+    }
+
+    // Take care of the selection points.
+    @Override
+    public void selector(Location loc)
+    {
+        if (name == null)
+        {
+            Util.messagePlayer(player, messages.getString("CREATOR.GENERAL.GiveNameInstruc"));
+            return;
+        }
+        plugin.canBreakBlock(player.getUniqueId(), player.getName(), loc)
+              .thenApply(canBreakBlock -> Bukkit.getScheduler().runTask(plugin, () -> selector(loc, canBreakBlock)));
     }
 }

--- a/core/src/main/java/nl/pim16aap2/bigDoors/toolUsers/SlidingDoorCreator.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/toolUsers/SlidingDoorCreator.java
@@ -1,11 +1,12 @@
 package nl.pim16aap2.bigDoors.toolUsers;
 
-import org.bukkit.Location;
-import org.bukkit.entity.Player;
-
 import nl.pim16aap2.bigDoors.BigDoors;
 import nl.pim16aap2.bigDoors.util.DoorType;
 import nl.pim16aap2.bigDoors.util.Util;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
 
 public class SlidingDoorCreator extends ToolUser
 {
@@ -22,7 +23,7 @@ public class SlidingDoorCreator extends ToolUser
     @Override
     protected void triggerGiveTool()
     {
-        giveToolToPlayer(messages.getString("CREATOR.SLIDINGDOOR.StickLore"    ).split("\n"),
+        giveToolToPlayer(messages.getString("CREATOR.SLIDINGDOOR.StickLore").split("\n"),
                          messages.getString("CREATOR.SLIDINGDOOR.StickReceived").split("\n"));
     }
 
@@ -57,16 +58,8 @@ public class SlidingDoorCreator extends ToolUser
         return true;
     }
 
-    // Take care of the selection points.
-    @Override
-    public void selector(Location loc)
+    private void selector(Location loc, @Nullable String canBreakBlock)
     {
-        if (name == null)
-        {
-            Util.messagePlayer(player, messages.getString("CREATOR.GENERAL.GiveNameInstruc"));
-            return;
-        }
-        final String canBreakBlock = plugin.canBreakBlock(player.getUniqueId(), player.getName(), loc);
         if (canBreakBlock != null)
         {
             Util.messagePlayer(player, messages.getString("CREATOR.GENERAL.NoPermissionHere") + " " + canBreakBlock);
@@ -89,5 +82,18 @@ public class SlidingDoorCreator extends ToolUser
             setEngine();
             setIsDone(true);
         }
+    }
+
+    // Take care of the selection points.
+    @Override
+    public void selector(Location loc)
+    {
+        if (name == null)
+        {
+            Util.messagePlayer(player, messages.getString("CREATOR.GENERAL.GiveNameInstruc"));
+            return;
+        }
+        plugin.canBreakBlock(player.getUniqueId(), player.getName(), loc)
+              .thenApply(canBreakBlock -> Bukkit.getScheduler().runTask(plugin, () -> selector(loc, canBreakBlock)));
     }
 }

--- a/core/src/main/java/nl/pim16aap2/bigDoors/util/Util.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/util/Util.java
@@ -824,6 +824,16 @@ public final class Util
     }
 
     /**
+     * See {@link #exceptionally(Throwable, Object)} with a null fallback value.
+     *
+     * @return Always null
+     */
+    public static @Nullable <T> T exceptionally(Throwable throwable)
+    {
+        return exceptionally(throwable, null);
+    }
+
+    /**
      * Maps a group of CompletableFutures to a single CompletableFuture with a list of results.
      * <p>
      * The result will wait for each of the futures to complete and once all of them have completed gather the results


### PR DESCRIPTION
## Background Information

LuckPerms does not allow using the [Economy#playerHas(String, OfflinePlayer, String)](http://milkbowl.github.io/VaultAPI/net/milkbowl/vault/permission/Permission.html#playerHas-java.lang.String-org.bukkit.OfflinePlayer-java.lang.String-) method from Vault on the main thread without additional configuration, as shown [here](https://github.com/LuckPerms/LuckPerms/blob/536c9183fe6a2c3792f4ed83094551eb9450f4c1/bukkit/src/main/java/me/lucko/luckperms/bukkit/vault/LuckPermsVaultPermission.java#L154-L157).

Previously, BigDoors worked around this with a [horrific hack](https://github.com/PimvanderLoos/BigDoors/blob/5632eba7a688410d17611f960b02835cfb6abc91/core/src/main/java/nl/pim16aap2/bigDoors/compatibility/ProtectionCompatManager.java#L92-L106), which, while ugly, used to work fine for a long time.

## Problem & Solution

A few days ago, user VikEnd reported a server crash that may have been caused by the server killing the main thread after timing out waiting for BigDoors to complete the [get](https://github.com/PimvanderLoos/BigDoors/blob/5632eba7a688410d17611f960b02835cfb6abc91/core/src/main/java/nl/pim16aap2/bigDoors/compatibility/ProtectionCompatManager.java#L99) call.

To avoid running into this issue in the future, I decided to execute the offline permissions lookup asynchronously. I'm sure that LuckPerms has a reason for doing this (likely performance), so not hacking around this is likely a better solution regardless.

Because basically everything in BigDoors is executed on the main thread, this change has required structural changes to other parts of the plugin as well. Specifically the openers and tool users needed to be updated to be able to execute an async step in the process.
To avoid thread-safety issues, all steps that do not need to be performed asynchronously are still performed on the main thread.


## Overview of this PR:
Goals:
- Perform lookups for offline players asynchronously to avoid server stalls/crashes.
- Maintain as much backwards compatibility as possible for plugins using existing versions of the updated methods.
- Have a minimal impact on code structure.

Non-goals:
- Improving the structure and quality of the code. 
- Clean up Openers/Creators (e.g. by reducing code duplication.)
- Improve performance by running code asynchronously when possible.

---

The non-goals described above may seem desirable features. However, this project is in maintenance mode and I only intend to fix issues when they come up. Any structural improvements will be applied to [AnimatedArchitecture](https://github.com/PimvanderLoos/AnimatedArchitecture) instead.