### PR TITLE
Fix broken NMS in recent builds of Spigot+forks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 Alpha 0.1.8.47
+- Fix NMS code broken on recent builds of Spigot (and forks). Thanks, SlimeDog, for the bug report! Note that this fix drops support for older builds of Spigot and forks. For Spigot, a build from after August 12 is required (3856 or later). For Paper, build 126 or later is required. Forcing code generation will allow you to use older builds, but I would recommend just updating regardless.
 - Drop support for Konquest. It turns out that the hook had been broken for a while, and I haven't received any reports about it. If you're still using Konquest, please let me know!
 - Do not allow doors to be toggled before all plugins have been enabled. This fixes timeout issues caused by the scheduler not running yet. Thanks, SlimeDog, for the bug report!
 

--- a/core/src/main/java/nl/pim16aap2/bigDoors/codegeneration/CraftFallingBlockClassGenerator.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/codegeneration/CraftFallingBlockClassGenerator.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 import static net.bytebuddy.implementation.FieldAccessor.ofField;
 import static net.bytebuddy.implementation.FixedValue.value;
@@ -110,7 +111,8 @@ final class CraftFallingBlockClassGenerator extends ClassGenerator
         // Simple getters
         builder = builder.define(METHOD_IS_ON_GROUND).intercept(value(false));
         builder = builder.define(METHOD_TO_STRING).intercept(value("CraftFallingBlock"));
-        builder = builder.define(METHOD_GET_TYPE).intercept(value(EntityType.FALLING_BLOCK));
+        if (!Modifier.isFinal(METHOD_GET_TYPE.getModifiers()))
+            builder = builder.define(METHOD_GET_TYPE).intercept(value(EntityType.FALLING_BLOCK));
         builder = builder.define(METHOD_GET_DROP_ITEM).intercept(value(false));
         builder = builder.define(METHOD_CAN_HURT_ENTITIES).intercept(value(false));
         builder = builder.defineMethod(methodGetEntityHandle.getName(), classGeneratedEntityFallingBlock)

--- a/nms/v1_20_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/CustomCraftFallingBlock_V1_20_R1.java
+++ b/nms/v1_20_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/CustomCraftFallingBlock_V1_20_R1.java
@@ -6,7 +6,6 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_20_R1.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_20_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_20_R1.util.CraftMagicNumbers;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.FallingBlock;
 import org.bukkit.util.EulerAngle;
 import org.bukkit.util.Vector;
@@ -37,12 +36,6 @@ public class CustomCraftFallingBlock_V1_20_R1 extends CraftEntity implements Fal
     public String toString()
     {
         return "CraftFallingBlock";
-    }
-
-    @Override
-    public @NotNull EntityType getType()
-    {
-        return EntityType.FALLING_BLOCK;
     }
 
     @Override


### PR DESCRIPTION
- A recent change in Craftbukkit provides a final implementation of the "EntityType getType()" method from the Entity interface. Previously, subclasses of CraftEntity were required to define this method. You can find the specific commit [here](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/b76ceb4f5dbeeedb6e0cff3b4545779b137bc125#src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java).
Closes #14