### PR TITLE
Use ByteBuddy to support all builds of MC 1.20.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 Alpha 0.1.8.47
-- Fix NMS code broken on recent builds of Spigot (and forks). Thanks, SlimeDog, for the bug report! Note that this fix drops support for older builds of Spigot and forks. For Spigot, a build from after August 12 is required (3856 or later). For Paper, build 126 or later is required. Forcing code generation will allow you to use older builds, but I would recommend just updating regardless.
+- Fix NMS code broken on recent builds of Spigot (and forks). Thanks, SlimeDog, for the bug report!
 - Drop support for Konquest. It turns out that the hook had been broken for a while, and I haven't received any reports about it. If you're still using Konquest, please let me know!
 - Do not allow doors to be toggled before all plugins have been enabled. This fixes timeout issues caused by the scheduler not running yet. Thanks, SlimeDog, for the bug report!
 

--- a/core/src/main/java/nl/pim16aap2/bigDoors/BigDoors.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/BigDoors.java
@@ -2,6 +2,7 @@ package nl.pim16aap2.bigDoors;
 
 import nl.pim16aap2.bigDoors.GUI.GUI;
 import nl.pim16aap2.bigDoors.NMS.FallingBlockFactory;
+import nl.pim16aap2.bigDoors.NMS.FallingBlockFactoryProvider;
 import nl.pim16aap2.bigDoors.NMS.FallingBlockFactory_V1_11_R1;
 import nl.pim16aap2.bigDoors.NMS.FallingBlockFactory_V1_12_R1;
 import nl.pim16aap2.bigDoors.NMS.FallingBlockFactory_V1_13_R1;
@@ -19,7 +20,6 @@ import nl.pim16aap2.bigDoors.NMS.FallingBlockFactory_V1_19_R1;
 import nl.pim16aap2.bigDoors.NMS.FallingBlockFactory_V1_19_R1_1;
 import nl.pim16aap2.bigDoors.NMS.FallingBlockFactory_V1_19_R2;
 import nl.pim16aap2.bigDoors.NMS.FallingBlockFactory_V1_19_R3;
-import nl.pim16aap2.bigDoors.NMS.FallingBlockFactory_V1_20_R1;
 import nl.pim16aap2.bigDoors.codegeneration.FallbackGeneratorManager;
 import nl.pim16aap2.bigDoors.compatibility.FakePlayerCreator;
 import nl.pim16aap2.bigDoors.compatibility.ProtectionCompatManager;
@@ -216,12 +216,21 @@ public class BigDoors extends JavaPlugin implements Listener
 
         Bukkit.getPluginManager().registerEvents(new LoginMessageHandler(this), this);
 
-        validVersion = compatibleMCVer();
+        try
+        {
+            validVersion = compatibleMCVer();
+        }
+        catch (Exception | ExceptionInInitializerError e)
+        {
+            logger.logMessageToConsoleOnly("Failed to enable the plugin for this version of Minecraft!");
+            getMyLogger().logMessage(Level.SEVERE, Util.throwableToString(e));
+            validVersion = false;
+        }
         // Load the files for the correct version of Minecraft.
         if (!validVersion)
         {
             setDisabled(
-                "This version of Minecraft is not supported. Is the plugin up-to-date? Or enable code generation.");
+                "This version of Minecraft is not supported. Is the plugin up-to-date?");
             logger.logMessage("Trying to load the plugin on an incompatible version of Minecraft! (\""
                                   + (Bukkit.getServer().getClass().getPackage().getName().replace(".", ",")
                                            .split(",")[3])
@@ -867,7 +876,7 @@ public class BigDoors extends JavaPlugin implements Listener
                 fabf = new FallingBlockFactory_V1_19_R3();
                 break;
             case "v1_20_R1":
-                fabf = new FallingBlockFactory_V1_20_R1();
+                fabf = FallingBlockFactoryProvider.getFactory();
                 break;
             default:
                 if (config.allowCodeGeneration())

--- a/nms/v1_20_R1/pom.xml
+++ b/nms/v1_20_R1/pom.xml
@@ -32,5 +32,12 @@
             <version>0.1.8.47-ALPHA</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>${dependency.bytebuddy.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/nms/v1_20_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/CustomCraftEntityGenerator.java
+++ b/nms/v1_20_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/CustomCraftEntityGenerator.java
@@ -1,0 +1,73 @@
+package nl.pim16aap2.bigDoors.NMS;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.dynamic.scaffold.subclass.ConstructorStrategy;
+import net.bytebuddy.implementation.FixedValue;
+import org.bukkit.craftbukkit.v1_20_R1.CraftServer;
+import org.bukkit.entity.EntityType;
+
+import java.lang.reflect.Constructor;
+import java.util.Objects;
+
+/**
+ * Represents a class that can generate a subclass of {@link CustomCraftFallingBlock_V1_20_R1} that overrides the
+ * {@link org.bukkit.entity.Entity#getType()} method to return {@link EntityType#FALLING_BLOCK}.
+ * <p>
+ * Newer versions of Spigot/Paper/etc. have a final {@link org.bukkit.entity.Entity#getType()} method while older
+ * versions only have an abstract one.
+ */
+class CustomCraftEntityGenerator
+{
+    /**
+     * Gets a {@link FallingBlockFactory_V1_20_R1.CustomCraftFallingBlockFactory} that can be used to create new
+     * {@link CustomCraftFallingBlock_V1_20_R1} instances.
+     * @return The supplier for new {@link CustomCraftFallingBlock_V1_20_R1} instances.
+     */
+    public FallingBlockFactory_V1_20_R1.CustomCraftFallingBlockFactory getCraftEntitySupplier()
+    {
+        final Constructor<CustomCraftFallingBlock_V1_20_R1> ctor = Objects.requireNonNull(
+            getCraftEntityConstructor(), "Redefined CustomCraftFallingBlock constructor cannot be null!");
+
+        return (server, entity) -> {
+            try
+            {
+                return ctor.newInstance(server, entity);
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException("Failed to create a new CustomCraftFallingBlock instance!", e);
+            }
+        };
+    }
+
+    private Constructor<CustomCraftFallingBlock_V1_20_R1> getCraftEntityConstructor()
+    {
+        try
+        {
+            final Class<?> clz = getRedefinedClass();
+            //noinspection unchecked
+            return (Constructor<CustomCraftFallingBlock_V1_20_R1>)
+                clz.getConstructor(CraftServer.class, CustomEntityFallingBlock_V1_20_R1.class);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Failed to get the redefined class.", e);
+        }
+    }
+
+    private Class<?> getRedefinedClass()
+        throws NoSuchMethodException
+    {
+       DynamicType.Builder<?> builder = new ByteBuddy()
+           .subclass(CustomCraftFallingBlock_V1_20_R1.class, ConstructorStrategy.Default.IMITATE_SUPER_CLASS)
+           .name("CustomCraftFallingBlock_V1_20_R1$generated");
+
+       builder = builder
+           .define(org.bukkit.entity.Entity.class.getMethod("getType"))
+           .intercept(FixedValue.value(EntityType.FALLING_BLOCK));
+
+        //noinspection resource
+        return builder.make().load(getClass().getClassLoader()).getLoaded();
+    }
+}

--- a/nms/v1_20_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/CustomCraftFallingBlock_V1_20_R1.java
+++ b/nms/v1_20_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/CustomCraftFallingBlock_V1_20_R1.java
@@ -1,8 +1,8 @@
 package nl.pim16aap2.bigDoors.NMS;
 
 import org.bukkit.Material;
-import org.bukkit.Server;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.craftbukkit.v1_20_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_20_R1.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_20_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_20_R1.util.CraftMagicNumbers;
@@ -13,9 +13,9 @@ import org.jetbrains.annotations.NotNull;
 
 public class CustomCraftFallingBlock_V1_20_R1 extends CraftEntity implements FallingBlock, CustomCraftFallingBlock
 {
-    CustomCraftFallingBlock_V1_20_R1(final Server server, final CustomEntityFallingBlock_V1_20_R1 entity)
+    public CustomCraftFallingBlock_V1_20_R1(final CraftServer server, final CustomEntityFallingBlock_V1_20_R1 entity)
     {
-        super((org.bukkit.craftbukkit.v1_20_R1.CraftServer) server, entity);
+        super(server, entity);
         setVelocity(new Vector(0, 0, 0));
         setDropItem(false);
     }

--- a/nms/v1_20_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactoryProvider.java
+++ b/nms/v1_20_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactoryProvider.java
@@ -5,15 +5,31 @@ import org.bukkit.craftbukkit.v1_20_R1.entity.CraftEntity;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
+/**
+ * Provides a {@link FallingBlockFactory} for version 1.20.R1.
+ * <p>
+ * The exact type of {@link FallingBlockFactory} returned depends on the specific build of Spigot/Paper/etc.
+ * <p>
+ * Use {@link #getFactory()} to get a new {@link FallingBlockFactory} instance.
+ */
 public class FallingBlockFactoryProvider
 {
+    /**
+     * Creates a new {@link FallingBlockFactory} instance for version 1.20.R1 of Minecraft for the current server build.
+     *
+     * @return A new {@link FallingBlockFactory} instance.
+     */
     public static FallingBlockFactory getFactory()
     {
+        return new FallingBlockFactory_V1_20_R1(getCraftEntitySupplier());
+    }
+
+    private static FallingBlockFactory_V1_20_R1.CustomCraftFallingBlockFactory getCraftEntitySupplier()
+    {
         if (methodGetTypeIsFinal())
-            return new FallingBlockFactory_V1_20_R1();
+            return CustomCraftFallingBlock_V1_20_R1::new;
         else
-            throw new UnsupportedOperationException(
-                "This version of Spigot/Paper/etc is not supported! Please update your server to a more recent build!");
+            return new CustomCraftEntityGenerator().getCraftEntitySupplier();
     }
 
     /**

--- a/nms/v1_20_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactoryProvider.java
+++ b/nms/v1_20_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactoryProvider.java
@@ -1,0 +1,36 @@
+package nl.pim16aap2.bigDoors.NMS;
+
+import org.bukkit.craftbukkit.v1_20_R1.entity.CraftEntity;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+public class FallingBlockFactoryProvider
+{
+    public static FallingBlockFactory getFactory()
+    {
+        if (methodGetTypeIsFinal())
+            return new FallingBlockFactory_V1_20_R1();
+        else
+            throw new UnsupportedOperationException(
+                "This version of Spigot/Paper/etc is not supported! Please update your server to a more recent build!");
+    }
+
+    /**
+     * Checks the method {@link CraftEntity#getType()} to see if it is final.
+     *
+     * @return True if the method is final, false otherwise.
+     */
+    private static boolean methodGetTypeIsFinal()
+    {
+        try
+        {
+            final Method method = CraftEntity.class.getMethod("getType");
+            return Modifier.isFinal(method.getModifiers());
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Failed to analyze method CraftEntity#getType().", e);
+        }
+    }
+}

--- a/nms/v1_20_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_20_R1.java
+++ b/nms/v1_20_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_20_R1.java
@@ -10,7 +10,7 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_20_R1.CraftWorld;
 
-public class FallingBlockFactory_V1_20_R1 implements FallingBlockFactory
+class FallingBlockFactory_V1_20_R1 implements FallingBlockFactory
 {
     @Override
     public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)

--- a/nms/v1_20_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_20_R1.java
+++ b/nms/v1_20_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_20_R1.java
@@ -8,17 +8,27 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.craftbukkit.v1_20_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_20_R1.CraftWorld;
 
 class FallingBlockFactory_V1_20_R1 implements FallingBlockFactory
 {
+    private final CustomCraftFallingBlockFactory customCraftEntityConstructor;
+
+    FallingBlockFactory_V1_20_R1(CustomCraftFallingBlockFactory customCraftEntityConstructor)
+    {
+        this.customCraftEntityConstructor = customCraftEntityConstructor;
+    }
+
     @Override
     public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
     {
-        IBlockData blockData = ((NMSBlock_V1_20_R1) block).getMyBlockData();
-        CustomEntityFallingBlock_V1_20_R1 fBlockNMS
+        final IBlockData blockData = ((NMSBlock_V1_20_R1) block).getMyBlockData();
+        final CustomEntityFallingBlock_V1_20_R1 fBlockNMS
             = new CustomEntityFallingBlock_V1_20_R1(loc.getWorld(), loc.getX(), loc.getY(), loc.getZ(), blockData);
-        CustomCraftFallingBlock_V1_20_R1 entity = new CustomCraftFallingBlock_V1_20_R1(Bukkit.getServer(), fBlockNMS);
+
+        final CustomCraftFallingBlock_V1_20_R1 entity =
+            customCraftEntityConstructor.newCraftEntity((CraftServer) Bukkit.getServer(), fBlockNMS);
         entity.setCustomName("BigDoorsEntity");
         entity.setCustomNameVisible(false);
         return entity;
@@ -30,5 +40,10 @@ class FallingBlockFactory_V1_20_R1 implements FallingBlockFactory
         final Info blockInfo =
             Info.a((BlockBase) ((CraftWorld) world).getHandle().a_(new BlockPosition(x, y, z)).b());
         return new NMSBlock_V1_20_R1(world, x, y, z, blockInfo);
+    }
+
+    interface CustomCraftFallingBlockFactory
+    {
+        CustomCraftFallingBlock_V1_20_R1 newCraftEntity(CraftServer server, CustomEntityFallingBlock_V1_20_R1 entity);
     }
 }


### PR DESCRIPTION
A recent change in CraftBukkit provides a final implementation in the CraftEntity class for the previously-abstract method Entity#getType. This meant that this plugin no longer worked on updated builds of Spigot/Paper/etc. See #14.

This was fixed in #15 by removing this method so users could have a working version of this plugin on new builds of Spigot/Paper/etc. However, this meant that the plugin no longer worked on older builds, as our CustomCraftFallingBlock class (a subclass of CraftEntity) did not implement the getType method.

Using ByteBuddy, we now generate a new subclass of our CustomCraftFallingBlock class with the added getType method for builds that require it. This means that all builds of Spigot/Paper/etc for MC 1.20.1 are supported again.
ByteBuddy is only used when `CraftEntity#getType` is **not** final; in all other situations, the plugin will use the existing class.