### PR TITLE
Fix redstone blocks not activating powerblocks when placed by hand or using pistons

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Alpha 0.1.8.48
 - Add support for MC 1.20.2.
+- Fixed doors not being toggled when their powerblock is activated by placing a redstone block next to it either directly or using a piston. Thanks, zioforcella, for the bug report!
 
 Alpha 0.1.8.47
 - Fix NMS code broken on recent builds of Spigot (and forks). Thanks, SlimeDog, for the bug report!

--- a/core/src/main/java/nl/pim16aap2/bigDoors/handlers/RedstoneHandler.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/handlers/RedstoneHandler.java
@@ -5,15 +5,22 @@ import nl.pim16aap2.bigDoors.Door;
 import nl.pim16aap2.bigDoors.util.ConfigLoader;
 import nl.pim16aap2.bigDoors.util.Util;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPistonExtendEvent;
+import org.bukkit.event.block.BlockPistonRetractEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.BlockRedstoneEvent;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class RedstoneHandler implements Listener
 {
@@ -34,7 +41,22 @@ public class RedstoneHandler implements Listener
             plugin.getDoorOpener(door.getType()).openDoorFuture(door, 0.0, false, true).exceptionally(Util::exceptionally);
     }
 
-    @EventHandler
+    private void checkAroundLocation(Block block)
+    {
+        for (final BlockFace dir : FACES)
+        {
+            final Block relative = block.getRelative(dir);
+            if (plugin.getConfigLoader().getPowerBlockTypes().contains(relative.getType()))
+                checkDoor(relative.getLocation());
+        }
+    }
+
+    private void checkAroundLocation(Location location)
+    {
+        checkAroundLocation(location.getBlock());
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     public void onBlockRedstoneChange(BlockRedstoneEvent event)
     {
         try
@@ -42,13 +64,7 @@ public class RedstoneHandler implements Listener
             final Block block = event.getBlock();
             if (event.getOldCurrent() != 0 && event.getNewCurrent() != 0)
                 return;
-
-            for (final BlockFace dir : FACES)
-            {
-                final Block relative = block.getRelative(dir);
-                if (plugin.getConfigLoader().getPowerBlockTypes().contains(relative.getType()))
-                    checkDoor(relative.getLocation());
-            }
+            checkAroundLocation(block);
         }
         catch (Exception e)
         {
@@ -57,5 +73,56 @@ public class RedstoneHandler implements Listener
             if (ConfigLoader.DEBUG)
                 e.printStackTrace();
         }
+    }
+
+    private void handleBlocksMovedByPiston(BlockFace direction, List<Block> blocks)
+    {
+        final Set<Location> addedPositions = new HashSet<>();
+        final Set<Location> removedPositions = new HashSet<>();
+
+        for (final Block block : blocks)
+        {
+            if (block.getType() != Material.REDSTONE_BLOCK)
+                continue;
+
+            final Location oldLocation = block.getLocation();
+            final Block newBlock = block.getRelative(direction);
+            final Location newLocation = newBlock.getLocation();
+
+            // Nothing changes if another redstone block replaces the current one.
+            if (addedPositions.contains(oldLocation))
+                addedPositions.remove(oldLocation);
+            else
+                removedPositions.add(oldLocation);
+
+            // Nothing happens if the current redstone block replaces another one.
+            if (removedPositions.contains(newLocation))
+                removedPositions.remove(newLocation);
+            else
+                addedPositions.add(newLocation);
+        }
+
+        addedPositions.forEach(this::checkAroundLocation);
+        removedPositions.forEach(this::checkAroundLocation);
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
+    public void onPistonExtend(BlockPistonExtendEvent event)
+    {
+        handleBlocksMovedByPiston(event.getDirection(), event.getBlocks());
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
+    public void onPistonRetract(BlockPistonRetractEvent event)
+    {
+        handleBlocksMovedByPiston(event.getDirection(), event.getBlocks());
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
+    public void onBlockPlace(BlockPlaceEvent event)
+    {
+        final Block block = event.getBlock();
+        if (plugin.getConfigLoader().getPowerBlockTypes().contains(block.getType()))
+            checkAroundLocation(block);
     }
 }


### PR DESCRIPTION
Placing a redstone block by hand or moving one using a (slime) piston does not fire a `BlockRedstoneEvent` for some reason. Therefore, BigDoors will now listen to blockplace and piston events to take care of any redstone blocks being placed.