### PR TITLE
Fix incompatiblity with recent SQLite JDBC Driver after sudden breaking change

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Alpha 0.1.8.48
 - Add support for MC 1.20.2.
+- Fixed database error after sudden breaking change in the SQLite JDBC driver. Thanks, Bonn2, for the bug report!
 - Fixed doors not being toggled when their powerblock is activated by placing a redstone block next to it either directly or using a piston. Thanks, zioforcella, for the bug report!
 
 Alpha 0.1.8.47

--- a/core/src/main/java/nl/pim16aap2/bigDoors/UpdateChecker.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/UpdateChecker.java
@@ -6,7 +6,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import nl.pim16aap2.bigDoors.util.Util;
-import org.apache.commons.lang.math.NumberUtils;
+import nl.pim16aap2.bigDoors.util.VersionScheme;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -25,8 +25,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.concurrent.CompletableFuture;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * A utility class to assist in checking for updates for plugins uploaded to
@@ -39,25 +37,6 @@ import java.util.regex.Pattern;
  */
 public final class UpdateChecker
 {
-    public static final VersionScheme VERSION_SCHEME_DECIMAL = (first, second) ->
-    {
-        String[] firstSplit = splitVersionInfo(first), secondSplit = splitVersionInfo(second);
-        if (firstSplit == null || secondSplit == null)
-            return null;
-
-        for (int i = 0; i < Math.min(firstSplit.length, secondSplit.length); i++)
-        {
-            int currentValue = NumberUtils.toInt(firstSplit[i]), newestValue = NumberUtils.toInt(secondSplit[i]);
-
-            if (newestValue > currentValue)
-                return second;
-            else if (newestValue < currentValue)
-                return first;
-        }
-
-        return (secondSplit.length > firstSplit.length) ? second : first;
-    };
-
     private static final URL UPDATE_URL;
     static
     {
@@ -75,8 +54,6 @@ public final class UpdateChecker
         }
         UPDATE_URL = url;
     }
-
-    private static final Pattern DECIMAL_SCHEME_PATTERN = Pattern.compile("\\d+(?:\\.\\d+)*");
 
     private static UpdateChecker instance;
 
@@ -194,15 +171,6 @@ public final class UpdateChecker
         return lastResult;
     }
 
-    private static String[] splitVersionInfo(String version)
-    {
-        Matcher matcher = DECIMAL_SCHEME_PATTERN.matcher(version);
-        if (!matcher.find())
-            return null;
-
-        return matcher.group().split("\\.");
-    }
-
     /**
      * Retrieves a member from a {@link JsonObject} as String.
      *
@@ -306,7 +274,7 @@ public final class UpdateChecker
      */
     public static UpdateChecker init(final BigDoors plugin)
     {
-        return init(plugin, VERSION_SCHEME_DECIMAL);
+        return init(plugin, VersionScheme.DECIMAL);
     }
 
     /**
@@ -345,27 +313,6 @@ public final class UpdateChecker
         TemporalAccessor temporalAccessor = DateTimeFormatter.ISO_INSTANT.parse(time);
         Date date = Date.from(Instant.from(temporalAccessor));
         return ((new Date()).getTime() - date.getTime()) / 1000;
-    }
-
-    /**
-     * A functional interface to compare two version Strings with similar version
-     * schemes.
-     */
-    @FunctionalInterface
-    public interface VersionScheme
-    {
-
-        /**
-         * Compare two versions and return the higher of the two. If null is returned,
-         * it is assumed that at least one of the two versions are unsupported by this
-         * version scheme parser.
-         *
-         * @param first  the first version to check
-         * @param second the second version to check
-         * @return the greater of the two versions. null if unsupported version schemes
-         */
-        String compareVersions(String first, String second);
-
     }
 
     /**

--- a/core/src/main/java/nl/pim16aap2/bigDoors/compatibility/ProtectionCompatManager.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/compatibility/ProtectionCompatManager.java
@@ -343,7 +343,9 @@ public class ProtectionCompatManager implements Listener
                             .getPlugin(compatDefinition.getName()).getDescription().getVersion();
 
             final Class<? extends IProtectionCompat> compatClass =
-                Objects.requireNonNull(compatDefinition.getClass(version), "Compat class cannot be null!");
+                Objects.requireNonNull(
+                    compatDefinition.getClass(version),
+                    "Compat class cannot be null for compat \"" + compatName + "\" (version \"" + version + "\")!");
 
             // No need to load compats twice.
             if (protectionAlreadyLoaded(compatClass))

--- a/core/src/main/java/nl/pim16aap2/bigDoors/util/VersionScheme.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/util/VersionScheme.java
@@ -1,0 +1,79 @@
+package nl.pim16aap2.bigDoors.util;
+
+import org.apache.commons.lang.math.NumberUtils;
+
+import javax.annotation.Nullable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A functional interface to compare two version Strings with similar version schemes.
+ */
+@FunctionalInterface
+public interface VersionScheme
+{
+    /**
+     * Compares two versions and return the higher of the two. If null is returned, it is assumed that at least one of
+     * the two versions are unsupported by this version scheme parser.
+     *
+     * @param first
+     *     The first version to check.
+     * @param second
+     *     The second version to check.
+     * @return The greater of the two versions or null if the format of at least one of the two versions is not valid.
+     */
+    @Nullable String compareVersions(String first, String second);
+
+    /**
+     * A version scheme that uses the decimal system to compare versions.
+     * <p>
+     * For example, "1.2.3" is considered a higher version than "1.2.2" and "1.2" but lower than "1.12".
+     */
+    VersionScheme DECIMAL = new Decimal();
+
+    /**
+     * A version scheme that uses the decimal system to compare versions.
+     * <p>
+     * For example, "1.2.3" is considered a higher version than "1.2.2" and "1.2" but lower than "1.12".
+     * <p>
+     * An instance of this class can be obtained through {@link #DECIMAL}.
+     */
+    final class Decimal implements VersionScheme
+    {
+        private static final Pattern DECIMAL_SCHEME_PATTERN = Pattern.compile("\\d+(?:\\.\\d+)*");
+
+        private Decimal()
+        {
+            // Should be obtained through the static field.
+        }
+
+        @Override
+        public @Nullable String compareVersions(String first, String second)
+        {
+            String[] firstSplit = splitVersionInfo(first), secondSplit = splitVersionInfo(second);
+            if (firstSplit == null || secondSplit == null)
+                return null;
+
+            for (int i = 0; i < Math.min(firstSplit.length, secondSplit.length); i++)
+            {
+                int currentValue = NumberUtils.toInt(firstSplit[i]), newestValue = NumberUtils.toInt(secondSplit[i]);
+
+                if (newestValue > currentValue)
+                    return second;
+                else if (newestValue < currentValue)
+                    return first;
+            }
+
+            return (secondSplit.length > firstSplit.length) ? second : first;
+        }
+
+        private static String[] splitVersionInfo(String version)
+        {
+            Matcher matcher = DECIMAL_SCHEME_PATTERN.matcher(version);
+            if (!matcher.find())
+                return null;
+
+            return matcher.group().split("\\.");
+        }
+    }
+}


### PR DESCRIPTION
- Xerial's SQLite JDBC driver yanked support for `Statement#getGeneratedKeys()` in release 3.43.0 without warning. Because this is the version used on 1.20.2, this meant that the database was broken on that version. Because the alternative method, the RETURNING clause, was only introduced in 2021 and our earliest supported version of MC was released in 2016, we ended up with some hacks to use both the old, suddenly-removed method when needed and the new method when possible.