### PR TITLE
Get rid of name on hover on 1.20.4+

### DIFF
--- a/core/src/main/java/nl/pim16aap2/bigDoors/BigDoors.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/BigDoors.java
@@ -57,6 +57,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.command.CommandExecutor;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
@@ -1075,6 +1076,22 @@ public class BigDoors extends JavaPlugin implements Listener
     {
         final Door door = getCommander().getDoor(null, doorUID);
         return toggleDoor(door, 0.0, false) == DoorOpenResult.SUCCESS;
+    }
+
+    /**
+     * Checks if a given entity is a BigDoors entity.
+     *
+     * @param entity The entity to check.
+     * @return True if the entity is a BigDoors entity.
+     *
+     * @throws RuntimeException If the plugin is not (correctly) enabled.
+     * You can use {@link #isEnabledSuccessfully()} to ensure the plugin is enabled correctly.
+     */
+    public boolean isBigDoorsEntity(@Nullable Entity entity)
+    {
+        if (fabf == null)
+            throw new RuntimeException("Falling Block Factory is null! The plugin is likely not enabled!");
+        return fabf.isBigDoorsEntity(entity);
     }
 
     // Check the open-status of a door.

--- a/core/src/main/java/nl/pim16aap2/bigDoors/codegeneration/FallingBlockFactoryClassGenerator.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/codegeneration/FallingBlockFactoryClassGenerator.java
@@ -136,9 +136,7 @@ public class FallingBlockFactoryClassGenerator extends ClassGenerator
         builder = builder
             .defineMethod(METHOD_POST_PROCESS, craftFallingBlockClassGenerator.getGeneratedClass(), Visibility.PRIVATE)
             .withParameters(craftFallingBlockClassGenerator.getGeneratedClass())
-            .intercept(invoke(methodSetCraftEntityCustomName).onArgument(0).with("BigDoorsEntity").andThen(
-                invoke(methodSetCraftEntityCustomNameVisible).onArgument(0).with(false)).andThen(
-                FixedValue.argument(0)));
+            .intercept(FixedValue.argument(0));
 
         final Method methodGetMyBlockData =
             ReflectionBuilder.findMethod().inClass(nmsBlockClassGenerator.getGeneratedClass())

--- a/core/src/main/java/nl/pim16aap2/bigDoors/codegeneration/ReflectionRepository.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/codegeneration/ReflectionRepository.java
@@ -133,8 +133,6 @@ final class ReflectionRepository
     public static final Method methodBlockInfoFromBlockBase;
     public static final Method methodGetTypeFromBlockPosition;
     public static final Method methodGetBukkitServer;
-    public static final Method methodSetCraftEntityCustomName;
-    public static final Method methodSetCraftEntityCustomNameVisible;
     public static final Method methodIsAssignableFrom;
     public static final Method methodSetBlockType;
     public static final Method methodEnumOrdinal;
@@ -326,10 +324,6 @@ final class ReflectionRepository
                                                      .withModifiers(Modifier.PUBLIC)
                                                      .withParameters(classBlockPosition).get();
         methodGetBukkitServer = findMethod().inClass(Bukkit.class).withName("getServer").get();
-        methodSetCraftEntityCustomName = findMethod().inClass(classCraftEntity).withName("setCustomName")
-                                                     .withParameters(String.class).get();
-        methodSetCraftEntityCustomNameVisible = findMethod()
-            .inClass(classCraftEntity).withName("setCustomNameVisible").withParameters(boolean.class).get();
         methodIsAssignableFrom = findMethod().inClass(Class.class).withName("isAssignableFrom")
                                              .withParameters(Class.class).get();
         methodSetBlockType = findMethod().inClass(Block.class).withName("setType")

--- a/core/src/main/java/nl/pim16aap2/bigDoors/handlers/CommandHandler.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/handlers/CommandHandler.java
@@ -373,7 +373,7 @@ public class CommandHandler implements CommandExecutor
     {
         for (World world : Bukkit.getWorlds())
             for (Entity entity : world.getEntities())
-                if (entity.getCustomName() != null && entity.getCustomName().equals("BigDoorsEntity"))
+                if (plugin.isBigDoorsEntity(entity))
                     entity.remove();
     }
 

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/BlockMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/BlockMover.java
@@ -3,6 +3,7 @@ package nl.pim16aap2.bigDoors.moveBlocks;
 import com.cryptomorin.xseries.XMaterial;
 import nl.pim16aap2.bigDoors.BigDoors;
 import nl.pim16aap2.bigDoors.Door;
+import nl.pim16aap2.bigDoors.NMS.FallingBlockFactory;
 import nl.pim16aap2.bigDoors.events.DoorEventAutoToggle;
 import nl.pim16aap2.bigDoors.events.DoorEventToggleEnd;
 import nl.pim16aap2.bigDoors.util.MyBlockData;
@@ -203,6 +204,21 @@ public abstract class BlockMover
     public final List<MyBlockData> getSavedBlocks()
     {
         return publicSavedBlocks;
+    }
+
+    /**
+     * Creates a new instance of the falling block factory specification.
+     * <p>
+     * This is used to configure the falling block factory.
+     *
+     * @param plugin The BigDoors plugin instance.
+     * @return The falling block factory specification.
+     */
+    protected static FallingBlockFactory.Specification createBlockFactorySpec(BigDoors plugin)
+    {
+        return new FallingBlockFactory.Specification(
+            plugin.getConfigLoader().setCustomName()
+        );
     }
 
     @FunctionalInterface

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/BridgeMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/BridgeMover.java
@@ -198,6 +198,8 @@ public class BridgeMover extends BlockMover
             new ArrayList<>(Math.min(door.getBlockCount(),
                                      (xMax - xMin + 1) * 2 + (yMax - yMin + 1) * 2 + (zMax - zMin + 1) * 2));
 
+        final FallingBlockFactory.Specification spec = createBlockFactorySpec(plugin);
+
         int xAxis = turningPoint.getBlockX();
         do
         {
@@ -274,7 +276,7 @@ public class BridgeMover extends BlockMover
 
                         CustomCraftFallingBlock fBlock = null;
                         if (!instantOpen)
-                            fBlock = fabf.fallingBlockFactory(newFBlockLocation, block, matData, mat);
+                            fBlock = fabf.createFallingBlockWithMetadata(spec, newFBlockLocation, block, matData, mat);
 
                         savedBlocks.add(new MyBlockData(mat, matByte, fBlock, radius, materialData,
                                                         block2 == null ? block : block2, canRotate, startLocation));
@@ -401,6 +403,8 @@ public class BridgeMover extends BlockMover
                     {
                         Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () ->
                         {
+                            final FallingBlockFactory.Specification spec = createBlockFactorySpec(plugin);
+
                             for (MyBlockData block : savedBlocks)
                             {
                                 if (block.canRot() != 0 && block.canRot() != 4)
@@ -413,7 +417,7 @@ public class BridgeMover extends BlockMover
                                     CustomCraftFallingBlock fBlock;
                                     // Because the block in savedBlocks is already rotated where applicable, just
                                     // use that block now.
-                                    fBlock = fabf.fallingBlockFactory(loc, block.getBlock(), matData, mat);
+                                    fBlock = fabf.createFallingBlockWithMetadata(spec, loc, block.getBlock(), matData, mat);
 
                                     block.getFBlock().remove();
                                     block.setFBlock(fBlock);

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/CylindricalMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/CylindricalMover.java
@@ -94,6 +94,8 @@ public class CylindricalMover extends BlockMover
             new ArrayList<>(Math.min(door.getBlockCount(),
                                      (xMax - xMin + 1) * 2 + (yMax - yMin + 1) * 2 + (zMax - zMin + 1) * 2));
 
+        final FallingBlockFactory.Specification spec = createBlockFactorySpec(plugin);
+
         int xAxis = turningPoint.getBlockX();
         do
         {
@@ -164,7 +166,7 @@ public class CylindricalMover extends BlockMover
 
                         CustomCraftFallingBlock fBlock = null;
                         if (!instantOpen)
-                            fBlock = fabf.fallingBlockFactory(newFBlockLocation, block, matData, mat);
+                            fBlock = fabf.createFallingBlockWithMetadata(spec, newFBlockLocation, block, matData, mat);
 
                         savedBlocks.add(new MyBlockData(mat, matByte, fBlock, radius, materialData,
                                                         block2 == null ? block : block2, canRotate, startLocation));
@@ -300,6 +302,8 @@ public class CylindricalMover extends BlockMover
                     if (replace)
                         Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () ->
                         {
+                            final FallingBlockFactory.Specification spec = createBlockFactorySpec(plugin);
+
                             for (MyBlockData block : savedBlocks)
                                 if (block.canRot() != 0 && block.canRot() != 5)
                                 {
@@ -311,7 +315,7 @@ public class CylindricalMover extends BlockMover
                                     CustomCraftFallingBlock fBlock;
                                     // Because the block in savedBlocks is already rotated where applicable, just
                                     // use that block now.
-                                    fBlock = fabf.fallingBlockFactory(loc, block.getBlock(), matData, mat);
+                                    fBlock = fabf.createFallingBlockWithMetadata(spec, loc, block.getBlock(), matData, mat);
 
                                     block.getFBlock().remove();
                                     block.setFBlock(fBlock);

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/SlidingMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/SlidingMover.java
@@ -98,6 +98,8 @@ public class SlidingMover extends BlockMover
             new ArrayList<>(Math.min(door.getBlockCount(),
                                      (xMax - xMin + 1) * 2 + (yMax - yMin + 1) * 2 + (zMax - zMin + 1) * 2));
 
+        final FallingBlockFactory.Specification spec = createBlockFactorySpec(plugin);
+
         int yAxis = yMin;
         do
         {
@@ -122,7 +124,7 @@ public class SlidingMover extends BlockMover
 
                         CustomCraftFallingBlock fBlock = null;
                         if (!instantOpen)
-                            fBlock = fabf.fallingBlockFactory(newFBlockLocation, block, matData, mat);
+                            fBlock = fabf.createFallingBlockWithMetadata(spec, newFBlockLocation, block, matData, mat);
                         savedBlocks
                             .add(new MyBlockData(mat, matData, fBlock, 0, materialData, block, 0, startLocation));
 

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/VerticalMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/VerticalMover.java
@@ -87,6 +87,8 @@ public class VerticalMover extends BlockMover
             new ArrayList<>(Math.min(door.getBlockCount(),
                                      (xMax - xMin + 1) * 2 + (yMax - yMin + 1) * 2 + (zMax - zMin + 1) * 2));
 
+        final FallingBlockFactory.Specification spec = createBlockFactorySpec(plugin);
+
         int yAxis = yMin;
         do
         {
@@ -111,7 +113,7 @@ public class VerticalMover extends BlockMover
 
                         CustomCraftFallingBlock fBlock = null;
                         if (!instantOpen)
-                            fBlock = fabf.fallingBlockFactory(newFBlockLocation, block, matData, mat);
+                            fBlock = fabf.createFallingBlockWithMetadata(spec, newFBlockLocation, block, matData, mat);
                         savedBlocks
                             .add(new MyBlockData(mat, matData, fBlock, 0, materialData, block, 0, startLocation));
 

--- a/core/src/main/java/nl/pim16aap2/bigDoors/util/ConfigLoader.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/util/ConfigLoader.java
@@ -58,6 +58,7 @@ public class ConfigLoader
     private String languageFile;
     private int maxDoorCount;
     private int countDoorsLevel;
+    private boolean setCustomName;
     private int cacheTimeout;
     private boolean announceUpdateCheck;
     private boolean autoDLUpdate;
@@ -244,6 +245,9 @@ public class ConfigLoader
         String[] allowNotificationsComment = { "Whether or not to allow toggle notifications. ",
                                                "When enabled, door creators can opt-in to receive notifications whenever a door is toggled.",
                                                "This is on a per-door basis."};
+        String[] setCustomNameComment = { "Sets the custom name 'BigDoorsEntity' for all animated blocks.",
+                                          "This can be useful for identifying animated blocks used by this plugin.",
+                                          "However, the name is visible on 1.20.4+ when you look at the entities." };
         String[] allowCodeGenerationComment = { "On unsupported versions of Minecraft, BigDoors can try to generate the required code itself.",
                                                 "This means that the plugin may work even on unsupported versions, ",
                                                 "but also that unexpected issues might pop up! Be sure to test everything when using this!",
@@ -386,6 +390,9 @@ public class ConfigLoader
 
         allowNotifications = config.getBoolean("allowNotifications", true);
         configOptionsList.add(new ConfigOption("allowNotifications", allowNotifications, allowNotificationsComment));
+
+        setCustomName = config.getBoolean("setCustomName", false);
+        configOptionsList.add(new ConfigOption("setCustomName", setCustomName, setCustomNameComment));
 
         allowCodeGeneration = config.getBoolean("allowCodeGeneration", true);
         configOptionsList.add(new ConfigOption("allowCodeGeneration", allowCodeGeneration, allowCodeGenerationComment));
@@ -848,5 +855,10 @@ public class ConfigLoader
     public int countDoorsLevel()
     {
         return countDoorsLevel;
+    }
+
+    public boolean setCustomName()
+    {
+        return setCustomName;
     }
 }

--- a/nms/nms-api/src/main/java/nl/pim16aap2/bigDoors/NMS/CustomCraftFallingBlock.java
+++ b/nms/nms-api/src/main/java/nl/pim16aap2/bigDoors/NMS/CustomCraftFallingBlock.java
@@ -1,10 +1,11 @@
 package nl.pim16aap2.bigDoors.NMS;
 
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 import org.bukkit.util.EulerAngle;
 import org.bukkit.util.Vector;
 
-public interface CustomCraftFallingBlock
+public interface CustomCraftFallingBlock extends Entity
 {
     boolean teleport(Location newPos);
 

--- a/nms/nms-api/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory.java
+++ b/nms/nms-api/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory.java
@@ -1,12 +1,120 @@
 package nl.pim16aap2.bigDoors.NMS;
 
+import nl.pim16aap2.bigDoors.util.LazyInit;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
 
 public interface FallingBlockFactory
 {
-    CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat);
+    /**
+     * The custom name of the falling block entity.
+     * <p>
+     * This used to be the recommended way to identify the falling block as a BigDoorsEntity.
+     * <p>
+     * By default, this is no longer used on newer versions of Minecraft.
+     * <p>
+     * Instead, use {@link #ENTITY_KEY} to identify the falling block as a BigDoorsEntity.
+     */
+    String ENTITY_NAME = "BigDoorsEntity";
+
+    /**
+     * The key for the metadata of the falling block entity.
+     * <p>
+     * This is used to identify the falling block as a BigDoorsEntity.
+     */
+    LazyInit<NamespacedKey> ENTITY_KEY = new LazyInit<>(
+        () -> new NamespacedKey(
+            Objects.requireNonNull(Bukkit.getPluginManager().getPlugin("BigDoors")),
+            "bigdoors_entity"));
+
+    /**
+     * Use {@link #createFallingBlockWithMetadata(Specification, Location, NMSBlock, byte, Material)} instead.
+     */
+    CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat);
+
+    /**
+     * Creates a falling block with metadata.
+     *
+     * @param data The data for the falling block factory.
+     * @param loc The location to spawn the falling block at.
+     * @param block The block to spawn as a falling block.
+     * @param matData The material data of the falling block.
+     * @param mat The material of the falling block.
+     * @return The falling block entity.
+     */
+    default CustomCraftFallingBlock createFallingBlockWithMetadata(
+        Specification data,
+        Location loc,
+        NMSBlock block,
+        byte matData,
+        Material mat)
+    {
+        final CustomCraftFallingBlock entity = createFallingBlock(loc, block, matData, mat);
+        setFallingBlockMetadata(data, entity);
+        return entity;
+    }
+
+    /**
+     * Sets the metadata of the falling block.
+     * <p>
+     * This is used to identify the falling block as a BigDoorsEntity.
+     *
+     * @param entity The falling block to set the metadata for.
+     */
+    default void setFallingBlockMetadata(Specification data, CustomCraftFallingBlock entity)
+    {
+        if (data.setCustomName)
+        {
+            entity.setCustomName(ENTITY_NAME);
+            entity.setCustomNameVisible(false);
+        }
+
+        entity.getPersistentDataContainer().set(ENTITY_KEY.get(), PersistentDataType.BYTE, (byte) 1);
+    }
 
     NMSBlock nmsBlockFactory(World world, int x, int y, int z);
+
+    /**
+     * Checks whether the entity is a BigDoorsEntity.
+     *
+     * @param entity The entity to check.
+     * @return True if the entity is a BigDoorsEntity, false otherwise.
+     */
+    default boolean isBigDoorsEntity(@Nullable Entity entity)
+    {
+        if (entity == null)
+            return false;
+
+        if (ENTITY_NAME.equals(entity.getCustomName()))
+            return true;
+
+        return entity.getPersistentDataContainer().has(ENTITY_KEY.get(), PersistentDataType.BYTE);
+    }
+
+    /**
+     * Data for the falling block factory.
+     */
+    final class Specification
+    {
+        private final boolean setCustomName;
+
+        /**
+         * Creates a new instance of the falling block factory data.
+         *
+         * @param setCustomName
+         *   Whether to set the custom name of the falling block.
+         */
+        public Specification(boolean setCustomName)
+        {
+            this.setCustomName = setCustomName;
+        }
+    }
 }

--- a/nms/v1_11_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_11_R1.java
+++ b/nms/v1_11_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_11_R1.java
@@ -9,13 +9,10 @@ public class FallingBlockFactory_V1_11_R1 implements FallingBlockFactory
 {
     // Make a falling block.
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         CustomEntityFallingBlock_V1_11_R1 fBlockNMS = new CustomEntityFallingBlock_V1_11_R1(loc.getWorld(), mat, loc.getX(), loc.getY(), loc.getZ(), matData);
-        CustomCraftFallingBlock_V1_11_R1 entity = new CustomCraftFallingBlock_V1_11_R1(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_11_R1(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_12_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_12_R1.java
+++ b/nms/v1_12_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_12_R1.java
@@ -9,13 +9,10 @@ public class FallingBlockFactory_V1_12_R1 implements FallingBlockFactory
 {
     // Make a falling block.
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         CustomEntityFallingBlock_V1_12_R1 fBlockNMS = new CustomEntityFallingBlock_V1_12_R1(loc.getWorld(), mat, loc.getX(), loc.getY(), loc.getZ(), matData);
-        CustomCraftFallingBlock_V1_12_R1 entity = new CustomCraftFallingBlock_V1_12_R1(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_12_R1(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_13_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_13_R1.java
+++ b/nms/v1_13_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_13_R1.java
@@ -1,25 +1,21 @@
 package nl.pim16aap2.bigDoors.NMS;
 
+import net.minecraft.server.v1_13_R1.Block;
+import net.minecraft.server.v1_13_R1.IBlockData;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 
-import net.minecraft.server.v1_13_R1.Block;
-import net.minecraft.server.v1_13_R1.IBlockData;
-
 public class FallingBlockFactory_V1_13_R1 implements FallingBlockFactory
 {
     // Make a falling block.
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         IBlockData blockData = ((Block) block).getBlockData();
         CustomEntityFallingBlock_V1_13_R1 fBlockNMS = new CustomEntityFallingBlock_V1_13_R1(loc.getWorld(), loc.getX(), loc.getY(), loc.getZ(), blockData);
-        CustomCraftFallingBlock_V1_13_R1 entity = new CustomCraftFallingBlock_V1_13_R1(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_13_R1(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_13_R1_5/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_13_R1_5.java
+++ b/nms/v1_13_R1_5/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_13_R1_5.java
@@ -1,25 +1,21 @@
 package nl.pim16aap2.bigDoors.NMS;
 
+import net.minecraft.server.v1_13_R2.Block;
+import net.minecraft.server.v1_13_R2.IBlockData;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 
-import net.minecraft.server.v1_13_R2.Block;
-import net.minecraft.server.v1_13_R2.IBlockData;
-
 public class FallingBlockFactory_V1_13_R1_5 implements FallingBlockFactory
 {
     // Make a falling block.
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         IBlockData blockData = ((Block) block).getBlockData();
         CustomEntityFallingBlock_V1_13_R1_5 fBlockNMS = new CustomEntityFallingBlock_V1_13_R1_5(loc.getWorld(), loc.getX(), loc.getY(), loc.getZ(), blockData);
-        CustomCraftFallingBlock_V1_13_R1_5 entity = new CustomCraftFallingBlock_V1_13_R1_5(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_13_R1_5(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_13_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_13_R2.java
+++ b/nms/v1_13_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_13_R2.java
@@ -1,25 +1,21 @@
 package nl.pim16aap2.bigDoors.NMS;
 
+import net.minecraft.server.v1_13_R2.Block;
+import net.minecraft.server.v1_13_R2.IBlockData;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 
-import net.minecraft.server.v1_13_R2.Block;
-import net.minecraft.server.v1_13_R2.IBlockData;
-
 public class FallingBlockFactory_V1_13_R2 implements FallingBlockFactory
 {
     // Make a falling block.
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         IBlockData blockData = ((Block) block).getBlockData();
         CustomEntityFallingBlock_V1_13_R2 fBlockNMS = new CustomEntityFallingBlock_V1_13_R2(loc.getWorld(), loc.getX(), loc.getY(), loc.getZ(), blockData);
-        CustomCraftFallingBlock_V1_13_R2 entity = new CustomCraftFallingBlock_V1_13_R2(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_13_R2(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_14_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_14_R1.java
+++ b/nms/v1_14_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_14_R1.java
@@ -1,25 +1,21 @@
 package nl.pim16aap2.bigDoors.NMS;
 
+import net.minecraft.server.v1_14_R1.Block;
+import net.minecraft.server.v1_14_R1.IBlockData;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 
-import net.minecraft.server.v1_14_R1.Block;
-import net.minecraft.server.v1_14_R1.IBlockData;
-
 public class FallingBlockFactory_V1_14_R1 implements FallingBlockFactory
 {
     // Make a falling block.
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         IBlockData blockData = ((Block) block).getBlockData();
         CustomEntityFallingBlock_V1_14_R1 fBlockNMS = new CustomEntityFallingBlock_V1_14_R1(loc.getWorld(), loc.getX(), loc.getY(), loc.getZ(), blockData);
-        CustomCraftFallingBlock_V1_14_R1 entity = new CustomCraftFallingBlock_V1_14_R1(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_14_R1(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_15_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_15_R1.java
+++ b/nms/v1_15_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_15_R1.java
@@ -1,26 +1,22 @@
 package nl.pim16aap2.bigDoors.NMS;
 
+import net.minecraft.server.v1_15_R1.IBlockData;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 
-import net.minecraft.server.v1_15_R1.IBlockData;
-
 public class FallingBlockFactory_V1_15_R1 implements FallingBlockFactory
 {
     // Make a falling block.
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         IBlockData blockData = ((NMSBlock_V1_15_R1) block).getMyBlockData();
         CustomEntityFallingBlock_V1_15_R1 fBlockNMS = new CustomEntityFallingBlock_V1_15_R1(loc.getWorld(), loc.getX(),
                                                                                             loc.getY(), loc.getZ(),
                                                                                             blockData);
-        CustomCraftFallingBlock_V1_15_R1 entity = new CustomCraftFallingBlock_V1_15_R1(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_15_R1(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_16_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_16_R1.java
+++ b/nms/v1_16_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_16_R1.java
@@ -1,30 +1,26 @@
 package nl.pim16aap2.bigDoors.NMS;
 
+import net.minecraft.server.v1_16_R1.BlockBase;
+import net.minecraft.server.v1_16_R1.BlockBase.Info;
+import net.minecraft.server.v1_16_R1.BlockPosition;
+import net.minecraft.server.v1_16_R1.IBlockData;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_16_R1.CraftWorld;
 
-import net.minecraft.server.v1_16_R1.BlockBase;
-import net.minecraft.server.v1_16_R1.BlockBase.Info;
-import net.minecraft.server.v1_16_R1.BlockPosition;
-import net.minecraft.server.v1_16_R1.IBlockData;
-
 public class FallingBlockFactory_V1_16_R1 implements FallingBlockFactory
 {
     // Make a falling block.
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         IBlockData blockData = ((NMSBlock_V1_16_R1) block).getMyBlockData();
         CustomEntityFallingBlock_V1_16_R1 fBlockNMS = new CustomEntityFallingBlock_V1_16_R1(loc.getWorld(), loc.getX(),
                                                                                             loc.getY(), loc.getZ(),
                                                                                             blockData);
-        CustomCraftFallingBlock_V1_16_R1 entity = new CustomCraftFallingBlock_V1_16_R1(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_16_R1(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_16_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_16_R2.java
+++ b/nms/v1_16_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_16_R2.java
@@ -1,30 +1,26 @@
 package nl.pim16aap2.bigDoors.NMS;
 
+import net.minecraft.server.v1_16_R2.BlockBase;
+import net.minecraft.server.v1_16_R2.BlockBase.Info;
+import net.minecraft.server.v1_16_R2.BlockPosition;
+import net.minecraft.server.v1_16_R2.IBlockData;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_16_R2.CraftWorld;
 
-import net.minecraft.server.v1_16_R2.BlockBase;
-import net.minecraft.server.v1_16_R2.BlockBase.Info;
-import net.minecraft.server.v1_16_R2.BlockPosition;
-import net.minecraft.server.v1_16_R2.IBlockData;
-
 public class FallingBlockFactory_V1_16_R2 implements FallingBlockFactory
 {
     // Make a falling block.
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         IBlockData blockData = ((NMSBlock_V1_16_R2) block).getMyBlockData();
         CustomEntityFallingBlock_V1_16_R2 fBlockNMS = new CustomEntityFallingBlock_V1_16_R2(loc.getWorld(), loc.getX(),
                                                                                             loc.getY(), loc.getZ(),
                                                                                             blockData);
-        CustomCraftFallingBlock_V1_16_R2 entity = new CustomCraftFallingBlock_V1_16_R2(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_16_R2(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_16_R3/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_16_R3.java
+++ b/nms/v1_16_R3/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_16_R3.java
@@ -1,30 +1,26 @@
 package nl.pim16aap2.bigDoors.NMS;
 
+import net.minecraft.server.v1_16_R3.BlockBase;
+import net.minecraft.server.v1_16_R3.BlockBase.Info;
+import net.minecraft.server.v1_16_R3.BlockPosition;
+import net.minecraft.server.v1_16_R3.IBlockData;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
 
-import net.minecraft.server.v1_16_R3.BlockBase;
-import net.minecraft.server.v1_16_R3.BlockBase.Info;
-import net.minecraft.server.v1_16_R3.BlockPosition;
-import net.minecraft.server.v1_16_R3.IBlockData;
-
 public class FallingBlockFactory_V1_16_R3 implements FallingBlockFactory
 {
     // Make a falling block.
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         IBlockData blockData = ((NMSBlock_V1_16_R3) block).getMyBlockData();
         CustomEntityFallingBlock_V1_16_R3 fBlockNMS = new CustomEntityFallingBlock_V1_16_R3(loc.getWorld(), loc.getX(),
                                                                                             loc.getY(), loc.getZ(),
                                                                                             blockData);
-        CustomCraftFallingBlock_V1_16_R3 entity = new CustomCraftFallingBlock_V1_16_R3(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_16_R3(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_17_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_17_R1.java
+++ b/nms/v1_17_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_17_R1.java
@@ -14,15 +14,12 @@ public class FallingBlockFactory_V1_17_R1 implements FallingBlockFactory
 {
     // Make a falling block.
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         IBlockData blockData = ((NMSBlock_V1_17_R1) block).getMyBlockData();
         CustomEntityFallingBlock_V1_17_R1 fBlockNMS
             = new CustomEntityFallingBlock_V1_17_R1(loc.getWorld(), loc.getX(), loc.getY(), loc.getZ(), blockData);
-        CustomCraftFallingBlock_V1_17_R1 entity = new CustomCraftFallingBlock_V1_17_R1(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_17_R1(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_18_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_18_R1.java
+++ b/nms/v1_18_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_18_R1.java
@@ -13,15 +13,12 @@ import org.bukkit.craftbukkit.v1_18_R1.CraftWorld;
 public class FallingBlockFactory_V1_18_R1 implements FallingBlockFactory
 {
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         IBlockData blockData = ((NMSBlock_V1_18_R1) block).getMyBlockData();
         CustomEntityFallingBlock_V1_18_R1 fBlockNMS
             = new CustomEntityFallingBlock_V1_18_R1(loc.getWorld(), loc.getX(), loc.getY(), loc.getZ(), blockData);
-        CustomCraftFallingBlock_V1_18_R1 entity = new CustomCraftFallingBlock_V1_18_R1(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_18_R1(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_18_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_18_R2.java
+++ b/nms/v1_18_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_18_R2.java
@@ -13,15 +13,12 @@ import org.bukkit.craftbukkit.v1_18_R2.CraftWorld;
 public class FallingBlockFactory_V1_18_R2 implements FallingBlockFactory
 {
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         IBlockData blockData = ((NMSBlock_V1_18_R2) block).getMyBlockData();
         CustomEntityFallingBlock_V1_18_R2 fBlockNMS
             = new CustomEntityFallingBlock_V1_18_R2(loc.getWorld(), loc.getX(), loc.getY(), loc.getZ(), blockData);
-        CustomCraftFallingBlock_V1_18_R2 entity = new CustomCraftFallingBlock_V1_18_R2(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_18_R2(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_19_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_19_R1.java
+++ b/nms/v1_19_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_19_R1.java
@@ -13,15 +13,12 @@ import org.bukkit.craftbukkit.v1_19_R1.CraftWorld;
 public class FallingBlockFactory_V1_19_R1 implements FallingBlockFactory
 {
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         IBlockData blockData = ((NMSBlock_V1_19_R1) block).getMyBlockData();
         CustomEntityFallingBlock_V1_19_R1 fBlockNMS
             = new CustomEntityFallingBlock_V1_19_R1(loc.getWorld(), loc.getX(), loc.getY(), loc.getZ(), blockData);
-        CustomCraftFallingBlock_V1_19_R1 entity = new CustomCraftFallingBlock_V1_19_R1(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_19_R1(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_19_R1_1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_19_R1_1.java
+++ b/nms/v1_19_R1_1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_19_R1_1.java
@@ -13,15 +13,12 @@ import org.bukkit.craftbukkit.v1_19_R1.CraftWorld;
 public class FallingBlockFactory_V1_19_R1_1 implements FallingBlockFactory
 {
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         IBlockData blockData = ((NMSBlock_V1_19_R1_1) block).getMyBlockData();
         CustomEntityFallingBlock_V1_19_R1_1 fBlockNMS
             = new CustomEntityFallingBlock_V1_19_R1_1(loc.getWorld(), loc.getX(), loc.getY(), loc.getZ(), blockData);
-        CustomCraftFallingBlock_V1_19_R1_1 entity = new CustomCraftFallingBlock_V1_19_R1_1(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_19_R1_1(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_19_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_19_R2.java
+++ b/nms/v1_19_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_19_R2.java
@@ -13,15 +13,12 @@ import org.bukkit.craftbukkit.v1_19_R2.CraftWorld;
 public class FallingBlockFactory_V1_19_R2 implements FallingBlockFactory
 {
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         IBlockData blockData = ((NMSBlock_V1_19_R2) block).getMyBlockData();
         CustomEntityFallingBlock_V1_19_R2 fBlockNMS
             = new CustomEntityFallingBlock_V1_19_R2(loc.getWorld(), loc.getX(), loc.getY(), loc.getZ(), blockData);
-        CustomCraftFallingBlock_V1_19_R2 entity = new CustomCraftFallingBlock_V1_19_R2(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_19_R2(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_19_R3/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_19_R3.java
+++ b/nms/v1_19_R3/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_19_R3.java
@@ -13,15 +13,12 @@ import org.bukkit.craftbukkit.v1_19_R3.CraftWorld;
 public class FallingBlockFactory_V1_19_R3 implements FallingBlockFactory
 {
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         IBlockData blockData = ((NMSBlock_V1_19_R3) block).getMyBlockData();
         CustomEntityFallingBlock_V1_19_R3 fBlockNMS
             = new CustomEntityFallingBlock_V1_19_R3(loc.getWorld(), loc.getX(), loc.getY(), loc.getZ(), blockData);
-        CustomCraftFallingBlock_V1_19_R3 entity = new CustomCraftFallingBlock_V1_19_R3(Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_19_R3(Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_20_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_20_R1.java
+++ b/nms/v1_20_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_20_R1.java
@@ -21,17 +21,13 @@ class FallingBlockFactory_V1_20_R1 implements FallingBlockFactory
     }
 
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         final IBlockData blockData = ((NMSBlock_V1_20_R1) block).getMyBlockData();
         final CustomEntityFallingBlock_V1_20_R1 fBlockNMS
             = new CustomEntityFallingBlock_V1_20_R1(loc.getWorld(), loc.getX(), loc.getY(), loc.getZ(), blockData);
 
-        final CustomCraftFallingBlock_V1_20_R1 entity =
-            customCraftEntityConstructor.newCraftEntity((CraftServer) Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return customCraftEntityConstructor.newCraftEntity((CraftServer) Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_20_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_20_R2.java
+++ b/nms/v1_20_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_20_R2.java
@@ -21,18 +21,13 @@ class FallingBlockFactory_V1_20_R2 implements FallingBlockFactory
     }
 
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         final IBlockData blockData = ((NMSBlock_V1_20_R2) block).getMyBlockData();
         final CustomEntityFallingBlock_V1_20_R2 fBlockNMS =
             customEntityFallingBlockFactory.newEntityFallingBlock(
                 loc.getWorld(), loc.getX(), loc.getY(), loc.getZ(), blockData);
-
-        final CustomCraftFallingBlock_V1_20_R2 entity =
-            new CustomCraftFallingBlock_V1_20_R2((CraftServer) Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_20_R2((CraftServer) Bukkit.getServer(), fBlockNMS);
     }
 
     @Override

--- a/nms/v1_20_R3/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_20_R3.java
+++ b/nms/v1_20_R3/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory_V1_20_R3.java
@@ -15,24 +15,21 @@ class FallingBlockFactory_V1_20_R3 implements FallingBlockFactory
 {
     private final CustomEntityFallingBlockFactory customEntityFallingBlockFactory;
 
+
     FallingBlockFactory_V1_20_R3(CustomEntityFallingBlockFactory customEntityFallingBlockFactory)
     {
         this.customEntityFallingBlockFactory = customEntityFallingBlockFactory;
     }
 
     @Override
-    public CustomCraftFallingBlock fallingBlockFactory(Location loc, NMSBlock block, byte matData, Material mat)
+    public CustomCraftFallingBlock createFallingBlock(Location loc, NMSBlock block, byte matData, Material mat)
     {
         final IBlockData blockData = ((NMSBlock_V1_20_R3) block).getMyBlockData();
         final CustomEntityFallingBlock_V1_20_R3 fBlockNMS =
             customEntityFallingBlockFactory.newEntityFallingBlock(
                 loc.getWorld(), loc.getX(), loc.getY(), loc.getZ(), blockData);
 
-        final CustomCraftFallingBlock_V1_20_R3 entity =
-            new CustomCraftFallingBlock_V1_20_R3((CraftServer) Bukkit.getServer(), fBlockNMS);
-        entity.setCustomName("BigDoorsEntity");
-        entity.setCustomNameVisible(false);
-        return entity;
+        return new CustomCraftFallingBlock_V1_20_R3((CraftServer) Bukkit.getServer(), fBlockNMS);
     }
 
     @Override


### PR DESCRIPTION
- Added a config option `setCustomName` to control whether animated blocks have a constum name. Default: false.
- Switched to PersistentDataContainer for animated entity identification instead of custom names.
- Added the method `boolean BigDoors#isBigDoorsEntity(Entity)` so other plugins can easily check if a specific entity is managed by this plugin.