### PR TITLE
Adapt to Paper's relocation changes + resource pack updates

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,6 @@
 Alpha 0.1.8.51
+- Added support for Paper 1.20.6.
+- Updated resource pack list.
 
 Alpha 0.1.8.50
 - Added support for MC 1.20.5.

--- a/core/src/main/java/nl/pim16aap2/bigDoors/GUI/GUI.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/GUI/GUI.java
@@ -2,7 +2,6 @@ package nl.pim16aap2.bigDoors.GUI;
 
 import com.cryptomorin.xseries.XMaterial;
 import nl.pim16aap2.bigDoors.BigDoors;
-import nl.pim16aap2.bigDoors.BigDoors.MCVersion;
 import nl.pim16aap2.bigDoors.Door;
 import nl.pim16aap2.bigDoors.util.DoorAttribute;
 import nl.pim16aap2.bigDoors.util.DoorDirection;
@@ -59,7 +58,7 @@ public class GUI
     static
     {
         // Ugly hack. I cannot be bothered to fix this properly.
-        if (MCVersion.v1_11_R1.equals(BigDoors.getMCVersion()) || MCVersion.v1_12_R1.equals(BigDoors.getMCVersion()))
+        if (!BigDoors.isOnFlattenedVersion())
         {
             DOORTYPES[0] = Material.getMaterial("WOOD_DOOR"); // Door
             DOORTYPES[1] = Material.getMaterial("TRAP_DOOR"); // DrawBridge

--- a/core/src/main/java/nl/pim16aap2/bigDoors/WorldHeightManager.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/WorldHeightManager.java
@@ -1,6 +1,7 @@
 package nl.pim16aap2.bigDoors;
 
 import nl.pim16aap2.bigDoors.reflection.ReflectionBuilder;
+import nl.pim16aap2.bigDoors.util.MinecraftVersion;
 import nl.pim16aap2.bigDoors.util.WorldHeightLimits;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -12,6 +13,8 @@ import java.util.Map;
 
 public class WorldHeightManager
 {
+    private static final MinecraftVersion VARIABLE_WORLD_DEPTH_UPDATE_VERSION = new MinecraftVersion(1, 18);
+
     private static final MinWorldHeightFinder MIN_WORLD_HEIGHT_FINDER = getMinWorldHeightFinder();
 
     private final Map<World, WorldHeightLimits> limitsMap = new HashMap<>();
@@ -36,7 +39,7 @@ public class WorldHeightManager
 
     private static MinWorldHeightFinder getMinWorldHeightFinder()
     {
-        if (!BigDoors.getMCVersion().isAtLeast(BigDoors.MCVersion.v1_18_R1))
+        if (MinecraftVersion.CURRENT_VERSION.isOlderThan(VARIABLE_WORLD_DEPTH_UPDATE_VERSION))
             return legacy -> 0;
 
         try

--- a/core/src/main/java/nl/pim16aap2/bigDoors/codegeneration/ReflectionRepository.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/codegeneration/ReflectionRepository.java
@@ -1,7 +1,7 @@
 package nl.pim16aap2.bigDoors.codegeneration;
 
 import com.cryptomorin.xseries.XMaterial;
-import nl.pim16aap2.bigDoors.BigDoors;
+import nl.pim16aap2.bigDoors.reflection.BukkitReflectionUtil;
 import nl.pim16aap2.bigDoors.reflection.ParameterGroup;
 import nl.pim16aap2.bigDoors.reflection.ReflectionBuilder;
 import org.bukkit.Bukkit;
@@ -154,8 +154,8 @@ final class ReflectionRepository
 
     static
     {
-        final String nmsBase = "net.minecraft.server." + BigDoors.get().getPackageVersion() + ".";
-        final String craftBase = "org.bukkit.craftbukkit." + BigDoors.get().getPackageVersion() + ".";
+        final String craftBase = BukkitReflectionUtil.CRAFT_BASE;
+        final String nmsBase = BukkitReflectionUtil.NMS_BASE;
 
         classEntityFallingBlock = findClass(nmsBase + "EntityFallingBlock",
                                             "net.minecraft.world.entity.item.EntityFallingBlock").get();

--- a/core/src/main/java/nl/pim16aap2/bigDoors/compatibility/FakePlayerInstantiator.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/compatibility/FakePlayerInstantiator.java
@@ -1,6 +1,6 @@
 package nl.pim16aap2.bigDoors.compatibility;
 
-import nl.pim16aap2.bigDoors.BigDoors;
+import nl.pim16aap2.bigDoors.reflection.BukkitReflectionUtil;
 import nl.pim16aap2.bigDoors.reflection.ReflectionBuilder;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
@@ -50,8 +50,8 @@ final class FakePlayerInstantiator
     {
         this.plugin = plugin;
 
-        final String nmsBase = "net.minecraft.server." + BigDoors.get().getPackageVersion() + ".";
-        final String craftBase = "org.bukkit.craftbukkit." + BigDoors.get().getPackageVersion() + ".";
+        final String craftBase = BukkitReflectionUtil.CRAFT_BASE;
+        final String nmsBase = BukkitReflectionUtil.NMS_BASE;
 
         classCraftOfflinePlayer = findClass(craftBase + "CraftOfflinePlayer").get();
         classCraftWorld = findClass(craftBase + "CraftWorld").get();

--- a/core/src/main/java/nl/pim16aap2/bigDoors/handlers/LoginResourcePackHandler.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/handlers/LoginResourcePackHandler.java
@@ -1,29 +1,36 @@
 package nl.pim16aap2.bigDoors.handlers;
 
 import nl.pim16aap2.bigDoors.BigDoors;
+import nl.pim16aap2.bigDoors.util.ResourcePackDetails;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.jetbrains.annotations.Nullable;
 
 public class LoginResourcePackHandler implements Listener
 {
-    BigDoors plugin;
-    String url;
+    private final BigDoors plugin;
+    private final @Nullable ResourcePackDetails resourcePackDetails;
 
-    public LoginResourcePackHandler(BigDoors plugin, String url)
+    public LoginResourcePackHandler(BigDoors plugin, @Nullable ResourcePackDetails resourcePackDetails)
     {
         this.plugin = plugin;
-        this.url = url;
+        this.resourcePackDetails = resourcePackDetails;
     }
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event)
     {
-        if (url == null)
+        if (resourcePackDetails == null)
         {
             plugin.getMyLogger().warn("No resource pack set! Please contact pim16aap2!");
             return;
         }
-        event.getPlayer().setResourcePack(url);
+
+        if (resourcePackDetails.getHash().length != 20)
+            event.getPlayer().setResourcePack(resourcePackDetails.getUrl());
+        else
+            event.getPlayer().setResourcePack(resourcePackDetails.getUrl(), resourcePackDetails.getHash());
+
     }
 }

--- a/core/src/main/java/nl/pim16aap2/bigDoors/util/ConfigLoader.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/util/ConfigLoader.java
@@ -2,7 +2,6 @@ package nl.pim16aap2.bigDoors.util;
 
 import com.cryptomorin.xseries.XMaterial;
 import nl.pim16aap2.bigDoors.BigDoors;
-import nl.pim16aap2.bigDoors.BigDoors.MCVersion;
 import nl.pim16aap2.bigDoors.compatibility.IProtectionCompatDefinition;
 import nl.pim16aap2.bigDoors.compatibility.ProtectionCompatDefinition;
 import org.bukkit.Bukkit;
@@ -16,7 +15,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -54,7 +52,7 @@ public class ConfigLoader
     private double flMultiplier = 1.0;
     private double elMultiplier = 1.0;
     private boolean resourcePackEnabled;
-    private String resourcePack;
+    private ResourcePackDetails resourcePack;
     private String languageFile;
     private int maxDoorCount;
     private int countDoorsLevel;
@@ -91,48 +89,10 @@ public class ConfigLoader
     public static boolean DEBUG = false;
     private final BigDoors plugin;
 
-    private static final MCVersion LATEST_RESOURCE_PACK_VERSION = MCVersion.v1_18_R1;
-    private static final EnumMap<MCVersion, String> RESOURCEPACKS = new EnumMap<>(MCVersion.class);
-    static
-    {
-        populateResourcePacks(
-            RESOURCEPACKS, "https://www.dropbox.com/s/6zdkg4jr90pc1mi/BigDoorsResourcePack-1_11.zip?dl=1",
-            MCVersion.v1_11_R1, MCVersion.v1_12_R1);
-
-        populateResourcePacks(
-            RESOURCEPACKS, "https://www.dropbox.com/s/al4idl017ggpnuq/BigDoorsResourcePack-1_13.zip?dl=1",
-            MCVersion.v1_13_R1, MCVersion.v1_13_R2, MCVersion.v1_14_R1);
-
-        populateResourcePacks(
-            RESOURCEPACKS, "https://www.dropbox.com/s/6zdkg4jr90pc1mi/BigDoorsResourcePack-1_15.zip?dl=1",
-            MCVersion.v1_15_R1, MCVersion.v1_16_R1, MCVersion.v1_16_R2, MCVersion.v1_16_R3);
-
-        populateResourcePacks(
-            RESOURCEPACKS, "https://www.dropbox.com/s/frkik8qpv3jep9v/BigDoorsResourcePack-Format7.zip?dl=1",
-            MCVersion.v1_17_R1);
-
-        populateResourcePacks(
-            RESOURCEPACKS, "https://www.dropbox.com/s/4pkvrpb9kmrq590/BigDoorsResourcePack-Format8.zip?dl=1",
-            MCVersion.v1_18_R1, MCVersion.v1_18_R2);
-
-        populateResourcePacks(
-            RESOURCEPACKS, "https://www.dropbox.com/s/mrft439gckhz2cw/BigDoorsResourcePack-Format9.zip?dl=1",
-            MCVersion.v1_19_R1);
-
-        populateResourcePacks(
-            RESOURCEPACKS, "https://www.dropbox.com/s/8vpwzjkd9jnp1xu/BigDoorsResourcePack-Format12.zip?dl=1",
-            MCVersion.v1_19_R2);
-
-        populateResourcePacks(
-            RESOURCEPACKS, "https://www.dropbox.com/s/3b6ohu02ueq5no0/BigDoorsResourcePack-Format13.zip?dl=1",
-            MCVersion.v1_19_R3);
-    }
-
     public ConfigLoader(BigDoors plugin)
     {
         this.plugin = plugin;
-        resourcePack = RESOURCEPACKS.getOrDefault(BigDoors.getMCVersion(),
-                                                  RESOURCEPACKS.get(LATEST_RESOURCE_PACK_VERSION));
+        resourcePack = ResourcePackDetails.getForVersion(MinecraftVersion.CURRENT_VERSION);
         configOptionsList = new ArrayList<>();
         powerBlockTypesMap = new HashSet<>();
         hooksMap = new HashMap<>(ProtectionCompatDefinition.DEFAULT_COMPAT_DEFINITIONS.size());
@@ -187,24 +147,9 @@ public class ConfigLoader
         String[] maxAutocloseTimerComment = { "The maximum value of an autoCloseTimer (specified in ticks). ",
                                               "A value of 6000 is 5 minutes. Use a negative value to allow unlimited values. " };
         String[] resourcePackComment = { "This plugin uses a support resource pack for things suchs as sound.",
-                                         "Different packs will be used for different versions of Minecraft:",
-                                         "The resource pack for 1.11.x/1.12.x is: '"
-                                             + RESOURCEPACKS.get(MCVersion.v1_11_R1) + "'",
-                                         "The resource pack for 1.13.x/1.14.x is: '"
-                                             + RESOURCEPACKS.get(MCVersion.v1_13_R1) + "'",
-                                         "The resource pack for 1.15.x/1.16.x is: '"
-                                             + RESOURCEPACKS.get(MCVersion.v1_15_R1) + "'",
-                                         "The resource pack for 1.17.x is: '"
-                                             + RESOURCEPACKS.get(MCVersion.v1_17_R1) + "'",
-                                         "The resource pack for 1.18.x is: '"
-                                             + RESOURCEPACKS.get(MCVersion.v1_18_R1) + "'",
-                                         "The resource pack for 1.19 - 1.19.2 is: '"
-                                             + RESOURCEPACKS.get(MCVersion.v1_19_R1) + "'",
-                                         "The resource pack for 1.19.3 is: '"
-                                             + RESOURCEPACKS.get(MCVersion.v1_19_R2) + "'",
-                                         "The resource pack for 1.19.4 is: '"
-                                             + RESOURCEPACKS.get(MCVersion.v1_19_R3) + "'",
-                                             };
+                                         "Different packs will be used for different versions of Minecraft.",
+                                         "The full list of resource packs per version can be found here:",
+                                         "https://github.com/PimvanderLoos/BigDoors/blob/master/core/src/main/java/nl/pim16aap2/bigDoors/util/ResourcePackDetails.java" };
         String[] multiplierComment = { "These multipliers affect the opening/closing speed of their respective door types.",
                                        "Note that the maximum speed is limited, so beyond a certain point rasising these values won't have any effect.",
                                        "To use the default values, set them to \"0.0\" or \"1.0\" (without quotation marks).",
@@ -596,12 +541,6 @@ public class ConfigLoader
         return Collections.unmodifiableList(ret);
     }
 
-    private static void populateResourcePacks(EnumMap<MCVersion, String> map, String url, MCVersion... versions)
-    {
-        for (final MCVersion version : versions)
-            map.put(version, url);
-    }
-
     public String dbFile()
     {
         return dbFile;
@@ -662,7 +601,7 @@ public class ConfigLoader
         return elMultiplier;
     }
 
-    public String resourcePack()
+    public ResourcePackDetails resourcePack()
     {
         return resourcePack;
     }

--- a/core/src/main/java/nl/pim16aap2/bigDoors/util/MinecraftVersion.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/util/MinecraftVersion.java
@@ -1,0 +1,191 @@
+package nl.pim16aap2.bigDoors.util;
+
+import org.bukkit.Bukkit;
+
+/**
+ * Represents a Minecraft version.
+ */
+public final class MinecraftVersion
+{
+    /**
+     * The current Minecraft version.
+     */
+    public static final MinecraftVersion CURRENT_VERSION = getCurrentVersion();
+
+    private final int major;
+    private final int minor;
+    private final int patch;
+
+    /**
+     * Creates a version object with the given major, minor and patch version.
+     * <p>
+     * For example, if major is 1, minor is 20 and patch is 5, this will create a version object representing version 1.20.5.
+     *
+     * @param major The major version.
+     * @param minor The minor version.
+     * @param patch The patch version.
+     */
+    public MinecraftVersion(int major, int minor, int patch)
+    {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+    }
+
+    /**
+     * Creates a version object with the given major version and minor version. The patch version is set to 0.
+     * <p>
+     * For example, if major is 1 and minor is 20, this will create a version object representing version 1.20.0.
+     *
+     * @param major The major version.
+     * @param minor The minor version.
+     */
+    public MinecraftVersion(int major, int minor)
+    {
+        this(major, minor, 0);
+    }
+
+    /**
+     * Checks if the current version is at least the given version, inclusive.
+     * <p>
+     * For example, if the current version is 1.20.5, this method will return true if the provided version is at most 1.20.5.
+     *
+     * @param major The major version to compare to.
+     * @param minor The minor version to compare to.
+     * @param patch The patch version to compare to.
+     * @return True if the current version is at least the given version, false otherwise.
+     */
+    public boolean isAtLeast(int major, int minor, int patch)
+    {
+        if (this.major > major)
+            return true;
+        if (this.major < major)
+            return false;
+
+        if (this.minor > minor)
+            return true;
+        if (this.minor < minor)
+            return false;
+
+        return this.patch >= patch;
+    }
+
+    /**
+     * Checks if the current version is at least the given version, inclusive. The patch version is considered to be 0.
+     *
+     * @param major The major version to compare to.
+     * @param minor The minor version to compare to.
+     * @return True if the current version is at least the given version, false otherwise.
+     */
+    public boolean isAtLeast(int major, int minor)
+    {
+        return isAtLeast(major, minor, 0);
+    }
+
+    /**
+     * Checks if the current version is at least the given version, inclusive.
+     * <p>
+     * For example, if the current version is 1.20.5, this method will return true if the provided version is at most 1.20.5.
+     *
+     * @param other The version to compare to.
+     * @return True if the current version is at least the given version, false otherwise.
+     */
+    public boolean isAtLeast(MinecraftVersion other)
+    {
+        return isAtLeast(other.major, other.minor, other.patch);
+    }
+
+    /**
+     * Checks if the current version is at most the given version, exclusive.
+     *
+     * @param other The version to compare to, exclusive.
+     * @return True if the current version is at most the given version, false otherwise.
+     */
+    public boolean isOlderThan(MinecraftVersion other)
+    {
+        return !isAtLeast(other);
+    }
+
+    /**
+     * Checks if the current version is between the minimum and maximum version, inclusive.
+     *
+     * @param minVersion The minimum version, inclusive.
+     * @param maxVersion The maximum version, inclusive.
+     * @return True if this version is between the minimum and maximum version, false otherwise.
+     */
+    public boolean isBetween(MinecraftVersion minVersion, MinecraftVersion maxVersion)
+    {
+        if (!isAtLeast(minVersion))
+            return false;
+        return equals(maxVersion) || isOlderThan(maxVersion);
+    }
+
+    /**
+     * Gets the major version.
+     *
+     * @return The major version.
+     */
+    public int getMajor()
+    {
+        return major;
+    }
+
+    /**
+     * Gets the minor version.
+     *
+     * @return The minor version.
+     */
+    public int getMinor()
+    {
+        return minor;
+    }
+
+    /**
+     * Gets the patch version.
+     *
+     * @return The patch version.
+     */
+    public int getPatch()
+    {
+        return patch;
+    }
+
+    private static MinecraftVersion getCurrentVersion()
+    {
+        final String versionString = Bukkit.getServer().getBukkitVersion();
+        // Parse e.g. "1.20.6-R0.1-SNAPSHOT" or "1.20-R0.1-SNAPSHOT" into [1, 20, 6] or [1, 20, 0] respectively.
+        final String[] versionParts = versionString.split("[.\\-]");
+
+        return new MinecraftVersion(
+            Integer.parseInt(versionParts[0]),
+            Integer.parseInt(versionParts[1]),
+            versionParts.length > 2 ? Integer.parseInt(versionParts[2]) : 0);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int hash = 17;
+        hash = 31 * hash + major;
+        hash = 31 * hash + minor;
+        hash = 31 * hash + patch;
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj)
+            return true;
+        if (obj == null || getClass() != obj.getClass())
+            return false;
+        final MinecraftVersion other = (MinecraftVersion) obj;
+        return major == other.major && minor == other.minor && patch == other.patch;
+    }
+
+    @Override
+    public String toString()
+    {
+        return major + "_" + minor + "_" + patch;
+    }
+}

--- a/core/src/main/java/nl/pim16aap2/bigDoors/util/ResourcePackDetails.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/util/ResourcePackDetails.java
@@ -1,0 +1,198 @@
+package nl.pim16aap2.bigDoors.util;
+
+import com.google.common.io.BaseEncoding;
+
+import java.util.Locale;
+
+/**
+ * Represents the details of the resource pack.
+ * <p>
+ * Each resource pack has a URL and a minimum and maximum version for which it is suitable.
+ * <p>
+ * The URL is the URL to the resource pack file.
+ * <p>
+ * The minimum and maximum version are the taken from the <a
+ * href="https://minecraft.fandom.com/wiki/Pack_format">wiki page</a>.
+ */
+public enum ResourcePackDetails
+{
+    FORMAT_3(
+        "https://www.dropbox.com/s/6zdkg4jr90pc1mi/BigDoorsResourcePack-1_11.zip?dl=1",
+        new MinecraftVersion(1, 11),
+        new MinecraftVersion(1, 12, 2)
+    ),
+
+    FORMAT_4(
+        "https://www.dropbox.com/scl/fi/bm29osi71pb70njyu5st8/BigDoorsResourcePack-Format4.zip?rlkey=cxolgh4bw4iiucnjkca789ofd&st=klrqaohl&dl=1",
+        new MinecraftVersion(1, 13),
+        new MinecraftVersion(1, 14, 4)
+    ),
+
+    FORMAT_5(
+        "https://www.dropbox.com/scl/fi/gg6bf8e30k89n7obvlpxc/BigDoorsResourcePack-Format5.zip?rlkey=l80rbfebfzb7zjnv2p814csxs&st=yeeu8ix4&dl=1",
+        new MinecraftVersion(1, 15),
+        new MinecraftVersion(1, 16, 1)
+    ),
+
+    FORMAT_6(
+        "https://www.dropbox.com/scl/fi/frc758gboe5xk1iz2jb4v/BigDoorsResourcePack-Format6.zip?rlkey=tp45b9m6dtgdka23mml535zid&st=zi7c5d2m&dl=6",
+        new MinecraftVersion(1, 16, 2),
+        new MinecraftVersion(1, 16, 5)
+    ),
+
+    FORMAT_7(
+        "https://www.dropbox.com/s/frkik8qpv3jep9v/BigDoorsResourcePack-Format7.zip?dl=1",
+        new MinecraftVersion(1, 17),
+        new MinecraftVersion(1, 17, 1)
+    ),
+
+    FORMAT_8(
+        "https://www.dropbox.com/s/4pkvrpb9kmrq590/BigDoorsResourcePack-Format8.zip?dl=1",
+        new MinecraftVersion(1, 18),
+        new MinecraftVersion(1, 18, 2)
+    ),
+
+    FORMAT_9(
+        "https://www.dropbox.com/s/mrft439gckhz2cw/BigDoorsResourcePack-Format9.zip?dl=1",
+        new MinecraftVersion(1, 19),
+        new MinecraftVersion(1, 19, 2)
+    ),
+
+    FORMAT_12(
+        "https://www.dropbox.com/s/8vpwzjkd9jnp1xu/BigDoorsResourcePack-Format12.zip?dl=1",
+        new MinecraftVersion(1, 19, 3),
+        new MinecraftVersion(1, 19, 3)
+    ),
+
+    FORMAT_13(
+        "https://www.dropbox.com/s/3b6ohu02ueq5no0/BigDoorsResourcePack-Format13.zip?dl=1",
+        new MinecraftVersion(1, 19, 4),
+        new MinecraftVersion(1, 19, 4)
+    ),
+
+    FORMAT_15(
+        "https://www.dropbox.com/scl/fi/bnfpjvmk9gm1470iohjdx/BigDoorsResourcePack-Format15.zip?rlkey=us8jfsq9cqqz5zy2c2bb7ufuc&st=cii8luqv&dl=1",
+        "759f22b5dc02edaf33e70fd89556248e85be92cf",
+        new MinecraftVersion(1, 20),
+        new MinecraftVersion(1, 20, 1)
+    ),
+
+    FORMAT_18(
+        "https://www.dropbox.com/scl/fi/6antz5z6qw0213st3qw81/BigDoorsResourcePack-Format18.zip?rlkey=oz4ghyajlhg7kkfma0iwveyph&st=p07goie9&dl=1",
+        "5d457693e69f26bd7657db0b7033ad68dd465409",
+        new MinecraftVersion(1, 20, 2),
+        new MinecraftVersion(1, 20, 2)
+    ),
+
+    FORMAT_23(
+        "https://www.dropbox.com/scl/fi/lv8uiy5kfryhqugtih53c/BigDoorsResourcePack-Format23.zip?rlkey=esxnipm5zmytp9pnfszrd6ims&st=tv7vs9ch&dl=1",
+        "c1e2037aa354ace6e929e448c9f288150f8aa646",
+        new MinecraftVersion(1, 20, 3),
+        new MinecraftVersion(1, 20, 4)
+    ),
+
+    FORMAT_32(
+        "https://www.dropbox.com/scl/fi/xh01ikoowsn4t82hgb06d/BigDoorsResourcePack-Format32.zip?rlkey=d9m1rb80dt1xq7giypxif3e4i&st=rjh7uskr&dl=1",
+        "4cab78f1f2e0183039ce252effe8ecb3f202632f",
+        new MinecraftVersion(1, 20, 5),
+        new MinecraftVersion(1, 20, 6)
+    ),
+
+    ;
+
+    private static final ResourcePackDetails[] VALUES = values();
+    private static final ResourcePackDetails LATEST = VALUES[VALUES.length - 1];
+
+    private final String url;
+    private final byte[] hash;
+    private final MinecraftVersion minVersion;
+    private final MinecraftVersion maxVersion;
+
+    ResourcePackDetails(String url, byte[] hash, MinecraftVersion minVersion, MinecraftVersion maxVersion)
+    {
+        this.url = url;
+        this.hash = hash;
+
+        this.minVersion = minVersion;
+        this.maxVersion = maxVersion;
+
+        if (this.hash.length != 0 && this.hash.length != 20)
+            throw new IllegalArgumentException("The hash must be empty or 20 bytes long! Got: " + this.hash.length + " bytes.");
+    }
+
+    ResourcePackDetails(String url, String hash, MinecraftVersion minVersion, MinecraftVersion maxVersion)
+    {
+        this(url, decodeHash(hash), minVersion, maxVersion);
+    }
+
+    ResourcePackDetails(String url, MinecraftVersion minVersion, MinecraftVersion maxVersion)
+    {
+        this(url, new byte[0], minVersion, maxVersion);
+    }
+
+    /**
+     * Decodes the hash from a hexadecimal string to a byte array.
+     *
+     * @param hash The hash to decode.
+     * @return The decoded hash.
+     */
+    private static byte[] decodeHash(String hash)
+    {
+        if (hash.isEmpty())
+            return new byte[0];
+
+        if (hash.length() != 40)
+            throw new IllegalArgumentException(
+                "The hash must be 40 characters long! Got: " + hash.length() + " characters.");
+
+        //noinspection UnstableApiUsage
+        return BaseEncoding.base16().decode(hash.toUpperCase(Locale.ROOT));
+    }
+
+    /**
+     * Finds the resource pack data most suitable for the given version.
+     * <p>
+     * If no suitable resource pack data is found, the latest resource pack data is returned.
+     *
+     * @param version The version for which to find the most suitable resource pack data.
+     * @return The resource pack data most suitable for the given version.
+     */
+    public static ResourcePackDetails getForVersion(MinecraftVersion version)
+    {
+        if (version.isOlderThan(LATEST.minVersion))
+            return LATEST;
+
+        for (int idx = VALUES.length - 1; idx >= 0; idx--)
+        {
+            final ResourcePackDetails data = VALUES[idx];
+            if (version.isBetween(data.minVersion, data.maxVersion))
+                return data;
+        }
+
+        return LATEST;
+    }
+
+    /**
+     * Gets the URL to the resource pack.
+     *
+     * @return The URL to the resource pack.
+     */
+    public String getUrl()
+    {
+        return url;
+    }
+
+    /**
+     * Gets the hash of the resource pack.
+     * <p>
+     * If no hash is set, an empty byte array is returned.
+     * <p>
+     * If provided, the hash is an SHA-1 hash of the resource pack (20 bytes).
+     *
+     * @return The hash of the resource pack.
+     */
+    public byte[] getHash()
+    {
+        return hash;
+    }
+}

--- a/core/src/main/java/nl/pim16aap2/bigDoors/util/Util.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/util/Util.java
@@ -671,7 +671,7 @@ public final class Util
             return true;
 
         if (name.endsWith("TRAPDOOR"))
-            return BigDoors.getMCVersion().isAtLeast(BigDoors.MCVersion.v1_18_R1);
+            return MinecraftVersion.CURRENT_VERSION.isAtLeast(new MinecraftVersion(1, 18));
 
         if (name.endsWith("BANNER") || name.endsWith("SHULKER_BOX") || name.endsWith("DOOR") ||
             name.endsWith("BED") || name.endsWith("SIGN") || name.endsWith("HEAD") || name.endsWith("SKULL"))
@@ -679,7 +679,7 @@ public final class Util
 
         if (name.endsWith("CARPET") || name.endsWith("BUTTON") || name.endsWith("PRESSURE_PLATE") ||
             name.endsWith("SAPLING") || name.endsWith("TORCH") || name.endsWith("RAIL") || name.endsWith("TULIP"))
-            return BigDoors.getMCVersion().isAtLeast(BigDoors.MCVersion.v1_18_R1);
+            return MinecraftVersion.CURRENT_VERSION.isAtLeast(new MinecraftVersion(1, 18));
 
         final @Nullable XMaterial xmat = matchXMaterial(mat);
         if (xmat == null)
@@ -740,7 +740,7 @@ public final class Util
         case AMETHYST_CLUSTER:
         case BIG_DRIPLEAF:
         case BIG_DRIPLEAF_STEM:
-            return BigDoors.getMCVersion().isAtLeast(BigDoors.MCVersion.v1_18_R1);
+            return MinecraftVersion.CURRENT_VERSION.isAtLeast(new MinecraftVersion(1, 18));
 
 
 

--- a/nms/v1_20_R4/pom.xml
+++ b/nms/v1_20_R4/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.20.5-R0.1-SNAPSHOT</version>
+            <version>1.20.6-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
- Adapted to Paper's recent change where craftbukkit is no longer relocated. This involved making some changes to reflection and server version parsing and handling.
- Updated the resource pack. There were several missing versions for recent Minecraft updates, which have now all been added in.