### PR TITLE
Fix plugin on versions before MC 1.20

### DIFF
--- a/core/src/main/java/nl/pim16aap2/bigDoors/toolUsers/ToolVerifier.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/toolUsers/ToolVerifier.java
@@ -30,9 +30,9 @@ public class ToolVerifier
 
     private static Enchantment findLuck()
     {
-        @Nullable Enchantment luck = Enchantment.getByName("luck");
+        @Nullable Enchantment luck = Enchantment.getByName("LUCK");
         if (luck == null)
-            luck = Enchantment.getByName("luck_of_the_sea");
+            luck = Enchantment.getByName("LUCK_OF_THE_SEA");
         return Objects.requireNonNull(luck, "Could not find the luck enchantment!");
     }
 }

--- a/nms/nms-api/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory.java
+++ b/nms/nms-api/src/main/java/nl/pim16aap2/bigDoors/NMS/FallingBlockFactory.java
@@ -34,11 +34,16 @@ public interface FallingBlockFactory
      * The key for the metadata of the falling block entity.
      * <p>
      * This is used to identify the falling block as a BigDoorsEntity.
+     * <p>
+     * If {@link #SUPPORTS_PERSISTENT_DATA_CONTAINER} is {@code false}, this will be {@code null}.
      */
-    LazyInit<NamespacedKey> ENTITY_KEY = new LazyInit<>(
-        () -> new NamespacedKey(
-            Objects.requireNonNull(Bukkit.getPluginManager().getPlugin("BigDoors")),
-            "bigdoors_entity"));
+    @Nullable LazyInit<NamespacedKey> ENTITY_KEY =
+        !SUPPORTS_PERSISTENT_DATA_CONTAINER ?
+            null :
+            new LazyInit<>(
+            () -> new NamespacedKey(
+                Objects.requireNonNull(Bukkit.getPluginManager().getPlugin("BigDoors")),
+                "bigdoors_entity"));
 
     /**
      * Use {@link #createFallingBlockWithMetadata(Specification, Location, NMSBlock, byte, Material)} instead.
@@ -82,7 +87,7 @@ public interface FallingBlockFactory
             entity.setCustomNameVisible(false);
         }
 
-        if (SUPPORTS_PERSISTENT_DATA_CONTAINER)
+        if (ENTITY_KEY != null)
             entity.getPersistentDataContainer().set(ENTITY_KEY.get(), PersistentDataType.BYTE, (byte) 1);
     }
 
@@ -102,7 +107,7 @@ public interface FallingBlockFactory
         if (ENTITY_NAME.equals(entity.getCustomName()))
             return true;
 
-        return SUPPORTS_PERSISTENT_DATA_CONTAINER &&
+        return ENTITY_KEY != null &&
             entity.getPersistentDataContainer().has(ENTITY_KEY.get(), PersistentDataType.BYTE);
     }
 


### PR DESCRIPTION
The plugin was broken on all versions prior to Minecraft 1.20 because of a broken enchantment lookup. 

Additionally, it was broken on version 1.11.* because it used the NamespacedKey class, which was not introduced until 1.12.